### PR TITLE
Remove .git from project URL.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
                 'input & text colours/positioning) and create ASCII '
                 'animations',
     long_description=long_description,
-    url='https://github.com/peterbrittain/asciimatics.git',
+    url='https://github.com/peterbrittain/asciimatics',
     author='Peter Brittain',
     author_email='peter.brittain.os@gmail.com',
     license='Apache 2.0',


### PR DESCRIPTION
Strictly the .git extension points at the git repo bundle, which is useful only for cloning the git repository. GitHub very kindly redirects browser requests for this URL to the HTML home page, but we should save GitHub the effort and point to the correct site.