### PR TITLE
Implementing MultiCheckBox

### DIFF
--- a/asciimatics/widgets.py
+++ b/asciimatics/widgets.py
@@ -1547,6 +1547,7 @@ class CheckBox(Widget):
         self._text = text
         self._label = label
         self._on_change = on_change
+        self._default_value = False
 
     def update(self, frame_no):
         self._draw_label()
@@ -1602,7 +1603,7 @@ class CheckBox(Widget):
     def value(self, new_value):
         # Only trigger the notification after we've changed the value.
         old_value = self._value
-        self._value = new_value if new_value else False
+        self._value = new_value if new_value else self._default_value
         if old_value != self._value and self._on_change:
             self._on_change()
 

--- a/doc/source/widgets.rst
+++ b/doc/source/widgets.rst
@@ -283,6 +283,7 @@ Widget type                   Description
 ============================= =====================================================================
 :py:obj:`.Button`             Action buttons - e.g. ok/cancel/etc.
 :py:obj:`.CheckBox`           Simple yes/no tick boxes.
+:py:obj:`.MultiCheckBox`      Like a CheckBox, but assumes arbitrary number of possibly non-Boolean values.
 :py:obj:`.Divider`            A spacer between widgets (for aesthetics).
 :py:obj:`.Label`              A label for a group of related widgets.
 :py:obj:`.ListBox`            A list of possible options from which users can select one value.

--- a/samples/forms.py
+++ b/samples/forms.py
@@ -1,5 +1,5 @@
 from asciimatics.widgets import Frame, TextBox, Layout, Label, Divider, Text, \
-    CheckBox, RadioButtons, Button, PopUpDialog
+    CheckBox, MultiCheckBox, RadioButtons, Button, PopUpDialog
 from asciimatics.scene import Scene
 from asciimatics.screen import Screen
 from asciimatics.exceptions import ResizeScreenError, NextScene, StopApplication, \
@@ -17,6 +17,7 @@ form_data = {
     "CA": False,
     "CB": True,
     "CC": False,
+    "MC": None,
 }
 
 
@@ -67,6 +68,9 @@ class DemoFrame(Frame):
             CheckBox("Field 2", name="CB", on_change=self._on_change), 1)
         layout.add_widget(
             CheckBox("Field 3", name="CC", on_change=self._on_change), 1)
+        layout.add_widget(
+            MultiCheckBox("MultiCheckBox", options=list("abcd"),
+                          name="MC", on_change=self._on_change), 1)
         layout.add_widget(Divider(height=3), 1)
         layout2 = Layout([1, 1, 1])
         self.add_layout(layout2)


### PR DESCRIPTION
First, thanks for the fantastic package you wrote, I was searching for something like this for quite a while!

Second, I'm not particularly sure whether it's needed, but I've added a new widget called `MultiCheckBox` which inherits from the `CheckBox` and it behaves that way, except a checkbox is limited to a Boolean whereas multicheckbox receives a list of possible values and cycles through them (by default it assumes `None` as its value). I guess it's relevant to #31 but such a widget wasn't mentioned there.

Third, I couldn't couldn't build the docs on my system (I get an error `ModuleNotFoundError: No module named 'setuptools_scm'`), so I'm not sure whether Sphinx pulls up my docstrings properly.