### PR TITLE
SQL parametrization fix to contact_list sample

### DIFF
--- a/samples/contact_list.py
+++ b/samples/contact_list.py
@@ -41,7 +41,7 @@ class ContactModel(object):
 
     def get_contact(self, contact_id):
         return self._db.cursor().execute(
-            "SELECT * from contacts where id=?", str(contact_id)).fetchone()
+            "SELECT * from contacts WHERE id=:id", {"id": contact_id}).fetchone()
 
     def get_current_contact(self):
         if self.current_id is None:


### PR DESCRIPTION
Fixed a small sql parameterization error in the contact_list sample which meant that it would fail for ids over 9. 
I just changed the get_contact() to use named parametrization to be inline with the other SQL functions.
