### PR TITLE
Add a read-only property for the current scene

### DIFF
--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -1489,6 +1489,14 @@ class Screen(with_metaclass(ABCMeta, _AbstractCanvas)):
             if scene.clear:
                 self.clear()
 
+    @property
+    def current_scene(self):
+        """
+        :return: The scene currently being rendered. To be used in conjunction
+        with :py:meth:`.draw_next_frame`.
+        """
+        return self._scenes[self._scene_index]
+
     def force_update(self):
         """
         Force the Screen to redraw the current Scene on the next call to


### PR DESCRIPTION
A getter for the current scene has been added to the screen object. This is required for handling screen resizes when the main loop is run manually by clients using draw_next_frame.

Tests are still passing.

Closes #144.