### PR TITLE
include license in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
 universal=1
+
+[metadata]
+# include the license file in the wheel
+license-file = LICENSE


### PR DESCRIPTION
Currently the `LICENSE` file isn't included in the distributed wheels.