### PR TITLE
Extended unicode awareness to widgets, canvas, and frames for reduced CPU overhead

### DIFF
--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -1018,6 +1018,8 @@ class Screen(with_metaclass(ABCMeta, _AbstractCanvas)):
     KEY_SHIFT = -600
     KEY_CONTROL = -601
     KEY_MENU = -602
+    KEY_RETURN = -603
+    KEY_SPACE = -604
 
     def __init__(self, height, width, buffer_height, unicode_aware):
         """
@@ -1609,6 +1611,8 @@ if sys.platform == "win32":
             win32con.VK_NEXT: Screen.KEY_PAGE_DOWN,
             win32con.VK_BACK: Screen.KEY_BACK,
             win32con.VK_TAB: Screen.KEY_TAB,
+            win32con.VK_RETURN: Screen.KEY_RETURN,
+            win32con.VK_SPACE: Screen.KEY_SPACE
         }
 
         _EXTRA_KEY_MAP = {

--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -1018,8 +1018,6 @@ class Screen(with_metaclass(ABCMeta, _AbstractCanvas)):
     KEY_SHIFT = -600
     KEY_CONTROL = -601
     KEY_MENU = -602
-    KEY_RETURN = -603
-    KEY_SPACE = -604
 
     def __init__(self, height, width, buffer_height, unicode_aware):
         """
@@ -1610,8 +1608,7 @@ if sys.platform == "win32":
             win32con.VK_PRIOR: Screen.KEY_PAGE_UP,
             win32con.VK_NEXT: Screen.KEY_PAGE_DOWN,
             win32con.VK_BACK: Screen.KEY_BACK,
-            win32con.VK_TAB: Screen.KEY_TAB,
-            win32con.VK_RETURN: Screen.KEY_RETURN
+            win32con.VK_TAB: Screen.KEY_TAB
         }
 
         _EXTRA_KEY_MAP = {
@@ -1980,8 +1977,7 @@ else:
             curses.KEY_NPAGE: Screen.KEY_PAGE_DOWN,
             curses.KEY_BACKSPACE: Screen.KEY_BACK,
             9: Screen.KEY_TAB,
-            curses.KEY_BTAB: Screen.KEY_BACK_TAB,
-            curses.KEY_ENTER: Screen.KEY_RETURN
+            curses.KEY_BTAB: Screen.KEY_BACK_TAB
             # Terminals translate keypad keys, so no need for a special
             # mapping here.
 

--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -497,7 +497,10 @@ class _AbstractCanvas(with_metaclass(ABCMeta, object)):
         The colours and attributes are the COLOUR_xxx and A_yyy constants
         defined in the Screen class.
         """
-        x = (self.width - wcswidth(text)) // 2
+        if self._unicode_aware:
+            x = (self.width - wcswidth(text)) // 2
+        else:
+            x = (self.width - len(text)) // 2
         self.paint(text, x, y, colour, attr, colour_map=colour_map)
 
     def paint(self, text, x, y, colour=7, attr=0, bg=0, transparent=False,

--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -1611,8 +1611,7 @@ if sys.platform == "win32":
             win32con.VK_NEXT: Screen.KEY_PAGE_DOWN,
             win32con.VK_BACK: Screen.KEY_BACK,
             win32con.VK_TAB: Screen.KEY_TAB,
-            win32con.VK_RETURN: Screen.KEY_RETURN,
-            win32con.VK_SPACE: Screen.KEY_SPACE
+            win32con.VK_RETURN: Screen.KEY_RETURN
         }
 
         _EXTRA_KEY_MAP = {
@@ -1982,6 +1981,7 @@ else:
             curses.KEY_BACKSPACE: Screen.KEY_BACK,
             9: Screen.KEY_TAB,
             curses.KEY_BTAB: Screen.KEY_BACK_TAB,
+            curses.KEY_ENTER: Screen.KEY_RETURN
             # Terminals translate keypad keys, so no need for a special
             # mapping here.
 

--- a/asciimatics/widgets.py
+++ b/asciimatics/widgets.py
@@ -2816,7 +2816,7 @@ class PopUpDialog(Frame):
         self._on_close = on_close
 
         # Decide on optimum width of the dialog.  Limit to 2/3 the screen width.
-        if self._canvas.unicode_aware:
+        if screen.unicode_aware:
             width = max([wcswidth(x) for x in text.split("\n")])
             width = max(width + 4,
                         sum([wcswidth(x) + 4 for x in buttons]) + len(buttons) + 5)
@@ -2828,7 +2828,7 @@ class PopUpDialog(Frame):
 
         # Figure out the necessary message and allow for buttons and borders
         # when deciding on height.
-        self._message = _split_text(text, width - 4, screen.height - 4, self._canvas.unicode_aware)
+        self._message = _split_text(text, width - 4, screen.height - 4, screen.unicode_aware)
         height = len(self._message) + 4
 
         # Construct the Frame


### PR DESCRIPTION
Eliminated the need to call wcwidth and wcswidth for non-unicode aware screens. This effect is inherited to frames, canvases, and widgets.