### PR TITLE
RadioButtons widget sets initial value

### DIFF
--- a/asciimatics/widgets.py
+++ b/asciimatics/widgets.py
@@ -1965,6 +1965,12 @@ class RadioButtons(Widget):
         self._start_column = 0
         self._on_change = on_change
 
+        # Attempt to set the value to the first option
+        try:
+            self._value = self._options[self._selection][1]
+        except:
+            pass
+
     def update(self, frame_no):
         self._draw_label()
 


### PR DESCRIPTION
If a user tabs through the radiobutton without changing the value, currently the _value is None.
This change makes a good faith attempt to set the default selection value on __init__.