### PR TITLE
screen: make _wait_for_input public

### DIFF
--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -1515,7 +1515,7 @@ class Screen(with_metaclass(ABCMeta, _AbstractCanvas)):
                 b = time.time()
                 if b - a < 0.05:
                     if allow_int:
-                        self._wait_for_input(a + 0.05 - b)
+                        self.wait_for_input(a + 0.05 - b)
                     else:
                         time.sleep(a + 0.05 - b)
         except StopApplication:
@@ -1679,7 +1679,7 @@ class Screen(with_metaclass(ABCMeta, _AbstractCanvas)):
         """
 
     @abstractmethod
-    def _wait_for_input(self, timeout):
+    def wait_for_input(self, timeout):
         """
         Wait until there is some input or the timeout is hit.
 
@@ -2048,7 +2048,7 @@ if sys.platform == "win32":
             except pywintypes.error:
                 pass
 
-        def _wait_for_input(self, timeout):
+        def wait_for_input(self, timeout):
             """
             Wait until there is some input or the timeout is hit.
 
@@ -2451,7 +2451,7 @@ else:
             self._cur_x = x + width
             self._cur_y = y
 
-        def _wait_for_input(self, timeout):
+        def wait_for_input(self, timeout):
             """
             Wait until there is some input or the timeout is hit.
 


### PR DESCRIPTION
First of all, thank you so much for this amazing project! We are using
it in our project [1] to interactively visualize dependency graphs for
our pipelines across all platforms. We are mostly using screen class
directly, as a cross platform ncurses of sorts and would love to have
an ability to use _wait_for_input method directly. In order to do that
properly, we need to make it formally public, so we could rely on it in
future versions of asciimatics.

I couldn't find any docs that need to be adjusted for this(seems
auto-generated), so please let me know if I need to add/change anything.

[1] https://github.com/iterative/dvc

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

# Thanks for taking the time to contibute to this project.  You are a star!

Checks
------
_Before you go any further, please make sure that you have read the [contributing guidelines](https://asciimatics.readthedocs.io/en/latest/contributing.html), run the test suite and that your clone of this repository was taken after 18 October 2018.  (I had to fix up the git history and so clones before that date will have all sorts of merge issues)._ 

_Now please delete this pre-amble section and fill in the rest of the template..._

Issues fixed by this PR
-----------------------
_Please list any Issues here_

What does this implement/fix?
-----------------------------
_Please add any further information about the fix if it is not obvious from the related Issue above_

Any other comments?
-------------------
_If there is anything else you feel you need to add, please do so here!_
