### PR TITLE
Stringify label

### DIFF
--- a/asciimatics/widgets.py
+++ b/asciimatics/widgets.py
@@ -1654,7 +1654,7 @@ class Label(Widget):
     def update(self, frame_no):
         (colour, attr, bg) = self._frame.palette["label"]
         for i, text in enumerate(
-                _split_text(self._text, self._w, self._h, self._frame.canvas.unicode_aware)):
+                _split_text(str(self._text), self._w, self._h, self._frame.canvas.unicode_aware)):
             self._frame.canvas.paint(
                 "{:{}{}}".format(text, self._align, self._w), self._x, self._y + i, colour, attr, bg)
 


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
Fixes a petty irritant.

What does this implement/fix?
-----------------------------
Prevents crash if label is set to non-string value (like a number).  People probably shouldn't do this, but the program shouldn't crash if they do.

Any other comments?
-------------------
Love the sublime retro aesthetic of asciimatics!
