### PR TITLE
variable star patterns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ LATEST
 - Added optional `theme` parameter to `PopupDialog`.
 - Added optional `jitter` parameter to `Noise`.
 - Improved performance of double-buffering.
+- Added optional `pattern` parameter to `Stars`.
 
   - NOTE: Drawing off-screen with a large scrolling buffer is no longer supported (as it wasn't
     needed).

--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -411,13 +411,12 @@ class _Star(object):
     Simple class to represent a single star for the Stars special effect.
     """
 
-    _star_chars = "..+..   ...x...  ...*...         "
-
-    def __init__(self, screen):
+    def __init__(self, screen, pattern):
         """
         :param screen: The Screen being used for the Scene.
         """
         self._screen = screen
+        self._star_chars = pattern
         self._cycle = None
         self._old_char = None
         self._respawn()
@@ -464,14 +463,14 @@ class Stars(Effect):
     Add random stars to the screen and make them twinkle.
     """
 
-    def __init__(self, screen, count, **kwargs):
+    def __init__(self, screen, count, pattern="..+..   ...x...  ...*...         ", **kwargs):
         """
         :param screen: The Screen being used for the Scene.
         :param count: The number of starts to create.
 
         Also see the common keyword arguments in :py:obj:`.Effect`.
         """
-        super(Stars, self).__init__(screen, **kwargs)
+        super(Stars, self).__init__(screen, pattern, **kwargs)
         self._max = count
         self._stars = []
 

--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -414,6 +414,7 @@ class _Star(object):
     def __init__(self, screen, pattern):
         """
         :param screen: The Screen being used for the Scene.
+        :param pattern: The pattern to loop through
         """
         self._screen = screen
         self._star_chars = pattern
@@ -467,7 +468,7 @@ class Stars(Effect):
         """
         :param screen: The Screen being used for the Scene.
         :param count: The number of starts to create.
-        :param pattern: The pattern the star loop through
+        :param pattern: The pattern for the stars to loop through
 
         Also see the common keyword arguments in :py:obj:`.Effect`.
         """

--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -470,12 +470,13 @@ class Stars(Effect):
 
         Also see the common keyword arguments in :py:obj:`.Effect`.
         """
-        super(Stars, self).__init__(screen, pattern, **kwargs)
+        super(Stars, self).__init__(screen, **kwargs)
+        self._pattern = pattern
         self._max = count
         self._stars = []
 
     def reset(self):
-        self._stars = [_Star(self._screen) for _ in range(self._max)]
+        self._stars = [_Star(self._screen, self._pattern) for _ in range(self._max)]
 
     def _update(self, frame_no):
         for star in self._stars:

--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -467,6 +467,7 @@ class Stars(Effect):
         """
         :param screen: The Screen being used for the Scene.
         :param count: The number of starts to create.
+        :param pattern: The pattern the star loop through
 
         Also see the common keyword arguments in :py:obj:`.Effect`.
         """

--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -468,7 +468,7 @@ class Stars(Effect):
         """
         :param screen: The Screen being used for the Scene.
         :param count: The number of starts to create.
-        :param pattern: The pattern for the stars to loop through
+        :param pattern: The string pattern for the stars to loop through
 
         Also see the common keyword arguments in :py:obj:`.Effect`.
         """

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -221,7 +221,7 @@ class TestEffects(unittest.TestCase):
         # Check that Stars randomly updates the Screen every frame.
         screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
         canvas = Canvas(screen, 10, 40, 0, 0)
-        effect = Stars(canvas, 100, "··xxx+++++xx···············")
+        effect = Stars(canvas, 100, "TESTTESTTEST")
         effect.reset()
         self.assert_blank(canvas)
         my_buffer = [[(32, 7, 0, 0) for _ in range(40)] for _ in range(10)]
@@ -230,7 +230,7 @@ class TestEffects(unittest.TestCase):
             self.assertTrue(self.check_canvas(
                 canvas,
                 my_buffer,
-                lambda value: self.assertIn(chr(value[0]), " ·x+")))
+                lambda value: self.assertIn(chr(value[0]), " TES")))
 
         # Check there is no stop frame by default.
         self.assertEqual(effect.stop_frame, 0)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -214,6 +214,31 @@ class TestEffects(unittest.TestCase):
         event = object()
         self.assertEqual(event, effect.process_event(event))
 
+    def test_stars_pattern(self):
+        """
+        Check that Stars custom pattern value works works.
+        """
+        # Check that Stars randomly updates the Screen every frame.
+        screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
+        canvas = Canvas(screen, 10, 40, 0, 0)
+        effect = Stars(canvas, 100, "··xxx+++++xx···············")
+        effect.reset()
+        self.assert_blank(canvas)
+        my_buffer = [[(32, 7, 0, 0) for _ in range(40)] for _ in range(10)]
+        for i in range(10):
+            effect.update(i)
+            self.assertTrue(self.check_canvas(
+                canvas,
+                my_buffer,
+                lambda value: self.assertIn(chr(value[0]), "·x+")))
+
+        # Check there is no stop frame by default.
+        self.assertEqual(effect.stop_frame, 0)
+
+        # This effect should ignore events.
+        event = object()
+        self.assertEqual(event, effect.process_event(event))
+
     def test_matrix(self):
         """
         Check that the Matrix works.

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -230,7 +230,7 @@ class TestEffects(unittest.TestCase):
             self.assertTrue(self.check_canvas(
                 canvas,
                 my_buffer,
-                lambda value: self.assertIn(chr(value[0]), "·x+")))
+                lambda value: self.assertIn(chr(value[0]), " ·x+")))
 
         # Check there is no stop frame by default.
         self.assertEqual(effect.stop_frame, 0)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -216,14 +216,13 @@ class TestEffects(unittest.TestCase):
 
     def test_stars_pattern(self):
         """
-        Check that Stars custom pattern value works works.
+        Check that Stars custom pattern value works.
         """
         # Check that Stars randomly updates the Screen every frame.
         screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
         canvas = Canvas(screen, 10, 40, 0, 0)
         effect = Stars(canvas, 100, "TESTTESTTEST")
         effect.reset()
-        self.assert_blank(canvas)
         my_buffer = [[(32, 7, 0, 0) for _ in range(40)] for _ in range(10)]
         for i in range(10):
             effect.update(i)
@@ -231,13 +230,6 @@ class TestEffects(unittest.TestCase):
                 canvas,
                 my_buffer,
                 lambda value: self.assertIn(chr(value[0]), " TES")))
-
-        # Check there is no stop frame by default.
-        self.assertEqual(effect.stop_frame, 0)
-
-        # This effect should ignore events.
-        event = object()
-        self.assertEqual(event, effect.process_event(event))
 
     def test_matrix(self):
         """


### PR DESCRIPTION
What does this implement/fix?
-----------------------------
I wanted to be able to set my own star patterns, like `··xxx+++++xx···············` and thought it would be helpful. This also lets users extend the `Stars` class and select a random pattern from a set without having to create a new `_Star` class.

Any other comments?
-------------------
It's pretty simple, you don't have to accept it I just thought it might be useful for people