### PR TITLE
Windows screen interrupt error fix

### DIFF
--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -2104,7 +2104,7 @@ if sys.platform == "win32":
 
             :param timeout: Time to wait for input in seconds (floating point).
             """
-            rc = win32event.WaitForSingleObject(self._stdin, long(timeout * 1000))
+            rc = win32event.WaitForSingleObject(self._stdin, int(timeout * 1000))
             if rc not in [0, 258]:
                 raise RuntimeError(rc)
 

--- a/asciimatics/screen.py
+++ b/asciimatics/screen.py
@@ -2104,7 +2104,7 @@ if sys.platform == "win32":
 
             :param timeout: Time to wait for input in seconds (floating point).
             """
-            rc = win32event.WaitForSingleObject(self._stdin, timeout * 1000)
+            rc = win32event.WaitForSingleObject(self._stdin, long(timeout * 1000))
             if rc not in [0, 258]:
                 raise RuntimeError(rc)
 


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
Fix for argument error to win32.event.WaitForSingleObject found on Windows 10 with Python 2.7.15.

What does this implement/fix?
-----------------------------
Attempting to run samples/contact_list.py on Windows 10 with Python 2.7.15 without this fix results in the following error:

```
File "C:\Python27\lib\site-packages\asciimatics\screen.py", line 2107, in wait_for_input
    rc = win32event.WaitForSingleObject(self._stdin, timeout * 1000)
SystemError: ..\Objects\longobject.c:463: bad argument to internal function
```

Not sure if this is the right fix, or the best fix, but samples/contact_list.py runs after it is applied, as do all the tests in the tests directory.

