### PR TITLE
Fix mouse events processing for _BaseListBox scroll bar

### DIFF
--- a/asciimatics/widgets.py
+++ b/asciimatics/widgets.py
@@ -2544,7 +2544,8 @@ class _BaseListBox(with_metaclass(ABCMeta, Widget)):
 
                 # Check for scroll bar interactions:
                 if self._scroll_bar:
-                    event = self._scroll_bar.process_event(event)
+                    if self._scroll_bar.process_event(event):
+                        return None
 
             # Ignore other mouse events.
             return event


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
In frames which contain ListBox with visible scroll bar mouse events meant for other widgets can be ignored.

What does this implement/fix?
-----------------------------
Return None if mouse event was processed by scroll bar instead of re-assigning event to True/False (result of _ScrollBar.process_event()). 

Any other comments?
-------------------
None