### PR TITLE
Make scripts runnable in macOS and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 develop-eggs/
 dist/
 eggs/
+.eggs/
 lib/
 lib64/
 parts/
@@ -23,6 +24,7 @@ var/
 .installed.cfg
 *.egg
 MANIFEST
+venv/
 
 # Installer logs
 pip-log.txt
@@ -46,3 +48,9 @@ docs/_build/
 
 # Workaround for setuptools_scm on RTD builds
 doc/source/conf.py
+# setuptools_scm-generated file
+asciimatics/version.py
+
+# Log files
+*.log
+

--- a/samples/256colour.py
+++ b/samples/256colour.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from asciimatics.effects import Print, Clock
 from asciimatics.renderers import FigletText, Rainbow

--- a/samples/bars.py
+++ b/samples/bars.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.effects import Print
 from asciimatics.renderers import BarChart, FigletText
 from asciimatics.scene import Scene

--- a/samples/basics.py
+++ b/samples/basics.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from builtins import range
 import copy

--- a/samples/bg_colours.py
+++ b/samples/bg_colours.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from asciimatics.effects import Wipe, Print
 from asciimatics.renderers import FigletText, SpeechBubble

--- a/samples/cogs.py
+++ b/samples/cogs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from asciimatics.effects import Cog, Print
 from asciimatics.renderers import FigletText

--- a/samples/contact_list.py
+++ b/samples/contact_list.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.widgets import Frame, ListBox, Layout, Divider, Text, \
     Button, TextBox, Widget
 from asciimatics.scene import Scene

--- a/samples/credits.py
+++ b/samples/credits.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from pyfiglet import Figlet
 

--- a/samples/experimental.py
+++ b/samples/experimental.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 
 from asciimatics.effects import Julia, Clock

--- a/samples/fire.py
+++ b/samples/fire.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.renderers import FigletText, Fire
 from asciimatics.scene import Scene
 from asciimatics.screen import Screen

--- a/samples/fireworks.py
+++ b/samples/fireworks.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.effects import Stars, Print
 from asciimatics.particles import RingFirework, SerpentFirework, StarFirework, \
     PalmFirework

--- a/samples/forms.py
+++ b/samples/forms.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.widgets import Frame, TextBox, Layout, Label, Divider, Text, \
     CheckBox, RadioButtons, Button, PopUpDialog, TimePicker, DatePicker, Background, DropdownList, \
     PopupMenu

--- a/samples/images.py
+++ b/samples/images.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from asciimatics.effects import BannerText, Print, Scroll
 from asciimatics.renderers import ColourImageFile, FigletText, ImageFile

--- a/samples/interactive.py
+++ b/samples/interactive.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.effects import Sprite, Print
 from asciimatics.event import KeyboardEvent, MouseEvent
 from asciimatics.exceptions import ResizeScreenError

--- a/samples/julia.py
+++ b/samples/julia.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.effects import Julia
 from asciimatics.scene import Scene
 from asciimatics.screen import Screen

--- a/samples/kaleidoscope.py
+++ b/samples/kaleidoscope.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from math import sqrt
 
 from asciimatics.renderers import Kaleidoscope, FigletText, Rainbow, RotatedDuplicate, \

--- a/samples/maps.py
+++ b/samples/maps.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # -*- coding: utf-8 -*-
 from __future__ import division
 from __future__ import print_function

--- a/samples/noise.py
+++ b/samples/noise.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.effects import RandomNoise
 from asciimatics.renderers import FigletText, Rainbow
 from asciimatics.scene import Scene

--- a/samples/pacman.py
+++ b/samples/pacman.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from copy import deepcopy
 import sys
 from asciimatics.exceptions import ResizeScreenError

--- a/samples/particles.py
+++ b/samples/particles.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from random import randint
 from asciimatics.effects import Print
 from asciimatics.particles import Explosion, StarFirework, DropScreen, Rain, \

--- a/samples/plasma.py
+++ b/samples/plasma.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from random import choice
 from asciimatics.renderers import Plasma, Rainbow, FigletText
 from asciimatics.scene import Scene

--- a/samples/quick_model.py
+++ b/samples/quick_model.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.widgets import Frame, ListBox, Layout, Divider, Text, \
     Button, TextBox, Widget
 from asciimatics.scene import Scene

--- a/samples/ray_casting.py
+++ b/samples/ray_casting.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # -*- coding: utf-8 -*-
 import sys
 from math import sin, cos, pi, copysign, floor

--- a/samples/rendering.py
+++ b/samples/rendering.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.renderers import BarChart
 from asciimatics.screen import Screen
 import sys

--- a/samples/simple.py
+++ b/samples/simple.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from asciimatics.effects import Cycle, Stars
 from asciimatics.renderers import FigletText

--- a/samples/terminal.py
+++ b/samples/terminal.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.widgets import Frame, TextBox, Layout, Background, Widget
 from asciimatics.scene import Scene
 from asciimatics.screen import Screen

--- a/samples/top.py
+++ b/samples/top.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.event import KeyboardEvent
 from asciimatics.widgets import Frame, Layout, MultiColumnListBox, Widget, Label, TextBox
 from asciimatics.scene import Scene

--- a/samples/treeview.py
+++ b/samples/treeview.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from asciimatics.event import KeyboardEvent
 from asciimatics.widgets import Frame, Layout, FileBrowser, Widget, Label, PopUpDialog, Text, \
     Divider

--- a/samples/xmas.py
+++ b/samples/xmas.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import division
 from asciimatics.effects import Cycle, Snow, Print
 from asciimatics.renderers import FigletText, StaticRenderer


### PR DESCRIPTION
Scripts should now be runnable with `./script.py`. This uses `#!/usr/bin/env python3` so python3 just needs to be on the path. (This lets it work both in Linux as well as in macOS when using `brew` or other third-party package manager.)

Added a few lines to .gitignore:
- `venv` -- for venv support
- `.eggs/` -- non-Windows `eggs/` directory.
- `asciimatics/version.py` -- file started out with a statement to not put it in version control, so it seemed an ommision.
- `*.log` -- At least one sample, when run, created a `.log` file. Logs are not normal things to check in.

I had these files created, but they were not checked in, and it seemed like they should never be checked in.

Issues fixed by this PR
-----------------------
Closes #248

What does this implement/fix?
-----------------------------
This makes the sample scripts more easily runnable on the command-line.

Any other comments?
-------------------
I love the product!
