### PR TITLE
Shorter lines are filled with spaces to have uniform speech bubble boxes

### DIFF
--- a/asciimatics/renderers.py
+++ b/asciimatics/renderers.py
@@ -473,12 +473,14 @@ class SpeechBubble(StaticRenderer):
         if uni:
             bubble = "╭─" + "─" * max_len + "─╮\n"
             for line in text.split("\n"):
-                bubble += "│ " + line + " │\n"
+                filler = " " * (max_len - len(line))
+                bubble += "│ " + line + filler + " │\n"
             bubble += "╰─" + "─" * max_len + "─╯\n"
         else:
             bubble = ".-" + "-" * max_len + "-.\n"
             for line in text.split("\n"):
-                bubble += "| " + line + " |\n"
+                filler = " " * (max_len - len(line))
+                bubble += "| " + line + filler + " |\n"
             bubble += "`-" + "-" * max_len + "-`\n"
         if tail == "L":
             bubble += "  )/  \n"

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -129,6 +129,19 @@ class TestRenderers(unittest.TestCase):
                          u"│ hello │\n"
                          u"╰───────╯\n")
 
+        # Multiline text rendering
+        text =  "Hello\n"       \
+                "World! \n"     \
+                "Hello World!"
+
+        renderer = SpeechBubble(text, uni=True)
+        self.assertEqual(str(renderer),
+                        "╭──────────────╮\n" +
+                        "│ Hello        │\n" +
+                        "│ World!       │\n" +
+                        "│ Hello World! │\n" +
+                        "╰──────────────╯\n")
+
     def test_box(self):
         """
         Check that the Box renderer works.


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
Fill with spaces the shortest lines in the speech bubble text to correctly render the right wall of the box

What does this implement/fix?
-----------------------------
When passing a multiline text to a Speech Bubble the **right wall** of the box is not render correctly, this happens when the line to render is shorter than the longest line
```
text = "WELCOME TO ASCIIMATICS\n" \
           "My name is Aristotle Arrow.\n" \
           "I'm here to help you learn ASCIImatics."

effects.append(Print(screen, SpeechBubble(text, tail='L'), 5, 10))

```
![image](https://user-images.githubusercontent.com/23131424/82721803-d15c5600-9c8e-11ea-8481-fa2ae4ddf90f.png)

If we fill the shortest lines with white spaces we can render all right walls in the same position as the longest line

![image](https://user-images.githubusercontent.com/23131424/82722192-6c0a6400-9c92-11ea-9dbe-84a8f3515b12.png)
