### PR TITLE
Fix speech bubble height

### DIFF
--- a/asciimatics/renderers.py
+++ b/asciimatics/renderers.py
@@ -475,17 +475,19 @@ class SpeechBubble(StaticRenderer):
             for line in text.split("\n"):
                 filler = " " * (max_len - len(line))
                 bubble += "│ " + line + filler + " │\n"
-            bubble += "╰─" + "─" * max_len + "─╯\n"
+            bubble += "╰─" + "─" * max_len + "─╯"
         else:
             bubble = ".-" + "-" * max_len + "-.\n"
             for line in text.split("\n"):
                 filler = " " * (max_len - len(line))
                 bubble += "| " + line + filler + " |\n"
-            bubble += "`-" + "-" * max_len + "-`\n"
+            bubble += "`-" + "-" * max_len + "-`"
         if tail == "L":
+            bubble += "\n"
             bubble += "  )/  \n"
             bubble += "-\"`\n"
         elif tail == "R":
+            bubble += "\n"
             bubble += (" " * max_len) + "\\(  \n"
             bubble += (" " * max_len) + " `\"-\n"
         self._images = [bubble]

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -102,7 +102,7 @@ class TestRenderers(unittest.TestCase):
         self.assertEqual(str(renderer),
                          ".-------.\n" +
                          "| hello |\n" +
-                         "`-------`\n")
+                         "`-------`")
 
         # Left bubble.
         renderer = SpeechBubble("world", tail="L")
@@ -127,20 +127,24 @@ class TestRenderers(unittest.TestCase):
         self.assertEqual(str(renderer),
                          u"╭───────╮\n"
                          u"│ hello │\n"
-                         u"╰───────╯\n")
+                         u"╰───────╯")
 
         # Multiline text rendering
-        text =  "Hello\n"       \
-                "World! \n"     \
-                "Hello World!"
+        text = "Hello\n" \
+               "World! \n" \
+               "Hello World!"
 
         renderer = SpeechBubble(text, uni=True)
         self.assertEqual(str(renderer),
-                        "╭──────────────╮\n" +
-                        "│ Hello        │\n" +
-                        "│ World!       │\n" +
-                        "│ Hello World! │\n" +
-                        "╰──────────────╯\n")
+                         "╭──────────────╮\n" +
+                         "│ Hello        │\n" +
+                         "│ World!       │\n" +
+                         "│ Hello World! │\n" +
+                         "╰──────────────╯")
+
+        # Test render height
+        renderer = SpeechBubble("Hello World", uni=True)
+        self.assertEqual(renderer.max_height, 3)
 
     def test_box(self):
         """
@@ -326,7 +330,7 @@ class TestRenderers(unittest.TestCase):
             # Create a base renderer
             plain_text = (".-------.\n" +
                           "| hello |\n" +
-                          "`-------`\n")
+                          "`-------`")
             renderer = SpeechBubble("hello")
             self.assertEqual(str(renderer), plain_text)
 
@@ -345,8 +349,7 @@ class TestRenderers(unittest.TestCase):
                     [(1, 1, None), (3, 1, None), (3, 1, None), (2, 1, None), (2, 1, None),
                      (6, 1, None), (6, 1, None), (4, 1, None), (4, 1, None)],
                     [(3, 1, None), (3, 1, None), (2, 1, None), (2, 1, None), (6, 1, None),
-                     (6, 1, None), (4, 1, None), (4, 1, None), (5, 1, None)],
-                    []])
+                     (6, 1, None), (4, 1, None), (4, 1, None), (5, 1, None)]])
 
         Screen.wrapper(internal_checks, height=15)
 


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
Height of the speech bubbles that not have a tail

What does this implement/fix?
-----------------------------
The way a render calculate the max height of its image its counting the lines in the image

`self._max_height = max(len(image), self._max_height)`

When constructing a speech bubble a new line is always added at the end of the bubble, whether or not it has a tail

```
 bubble = "╭─" + "─" * max_len + "─╮\n"
            for line in text.split("\n"):
                filler = " " * (max_len - len(line))
                bubble += "│ " + line + filler + " │\n"
            bubble += "╰─" + "─" * max_len + "─╯\n"
```

the last `\n` increase the bubble size by one by creating a new empty line. The new line is needed only when there is a tail