### PR TITLE
value added to Widget class constructor arguments

### DIFF
--- a/asciimatics/widgets.py
+++ b/asciimatics/widgets.py
@@ -1378,20 +1378,21 @@ class Widget(with_metaclass(ABCMeta, object)):
                  "_display_label", "_is_tab_stop", "_is_disabled", "_is_valid", "_custom_colour", "_on_focus",
                  "_on_blur", "string_len"]
 
-    def __init__(self, name, tab_stop=True, disabled=False, on_focus=None, on_blur=None):
+    def __init__(self, name, tab_stop=True, disabled=False, on_focus=None, on_blur=None, value=None):
         """
         :param name: The name of this Widget.
         :param tab_stop: Whether this widget should take focus or not when tabbing around the Frame.
         :param disabled: Whether this Widget should be disabled or not.
         :param on_focus: Optional callback whenever this widget gets the focus.
         :param on_blur: Optional callback whenever this widget loses the focus.
+        :param value: Optional provides a default value or act as placeholder.
         """
         super(Widget, self).__init__()
         # Internal properties
         self._name = name
         self._label = None
         self._frame = None
-        self._value = None
+        self._value = value
         self._has_focus = False
         self._x = self._y = 0
         self._w = self._h = 0


### PR DESCRIPTION
# Thanks for taking the time to contibute to this project.  You are a star!

Checks
------
_Before you go any further, please make sure that you have read the [contributing guidelines](https://asciimatics.readthedocs.io/en/latest/contributing.html), run the test suite and that your clone of this repository was taken after 18 October 2018.  (I had to fix up the git history and so clones before that date will have all sorts of merge issues)._ 

_Now please delete this pre-amble section and fill in the rest of the template..._

Issues fixed by this PR
-----------------------
Setting a pre-populate value needed extra effort when adding to a widget

What does this implement/fix?
-----------------------------
now in a one-liner, pre-populate value can be set in the widget via a constructor argument

Any other comments?
-------------------
I somewhere think that name "_value" or "value" is a little confusing because default text/"pre-populate value"/"placeholder text" is achieved via it.