### PR TITLE
fix: Fix invalid args on clear_buffer

### DIFF
--- a/samples/ray_casting.py
+++ b/samples/ray_casting.py
@@ -161,7 +161,7 @@ class RayCaster(Effect):
 
     def _update(self, _):
         # First draw the background - which is theoretically the floor and ceiling.
-        self._screen.clear_buffer(0, 0, 0, 0, 0, self._screen.width, self._screen.height)
+        self._screen.clear_buffer(0, 0, 0) #, 0, 0, self._screen.width, self._screen.height)
 
         # Now do the ray casting across the visible canvas.
         # Compensate for aspect ratio by treating 2 cells as a single pixel.


### PR DESCRIPTION
"TypeError: clear_buffer() takes 4 positional arguments but 8 were given"

# Thanks for taking the time to contibute to this project.  You are a star!

Checks
------
_Before you go any further, please make sure that you have read the [contributing guidelines](https://asciimatics.readthedocs.io/en/latest/contributing.html), run the test suite and that your clone of this repository was taken after 18 October 2018.  (I had to fix up the git history and so clones before that date will have all sorts of merge issues)._ 

_Now please delete this pre-amble section and fill in the rest of the template..._

Issues fixed by this PR
-----------------------
Runtime error on ray_casting.py

What does this implement/fix?
-----------------------------
Fixes: TypeError: clear_buffer() takes 4 positional arguments but 8 were given

Any other comments?
-------------------
Great project ! ! :)
