### PR TITLE
update win32 dependence (#275)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ To install asciimatics, simply install with `pip` as follows:
 This should install all your dependencies for you.  If you don't use pip or it fails to install
 them, you can install the dependencies directly using the packages listed in `requirements.txt
 <https://github.com/peterbrittain/asciimatics/blob/master/requirements.txt>`_.
-Additionally, Windows users (who aren't using `pip`) will need to install `pypiwin32`.
+Additionally, Windows users (who aren't using `pip`) will need to install `pywin32`.
 
 How to use it?
 --------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 
   # Project requirements
   - "python.exe -m pip install -r requirements/dev.txt"
-  - "python.exe -m pip install pypiwin32==219"
+  - "python.exe -m pip install pywin32"
 
 build: off
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -50,7 +50,7 @@ This should install all your dependencies for you.  If you don't use pip
 or it fails to install them, you can install the dependencies directly
 using the packages listed in `requirements.txt
 <https://github.com/peterbrittain/asciimatics/blob/master/requirements.txt>`_.
-Additionally, Windows users will need to install `pypiwin32`.
+Additionally, Windows users will need to install `pywin32`.
 
 Quick start guide
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         'backports.functools_lru_cache;python_version<"3.0"',
     ],
     extras_require={
-        ':sys_platform == "win32"': ['pypiwin32'],
+        ':sys_platform == "win32"': ['pywin32'],
     },
     setup_requires=['setuptools_scm'],
     tests_require=[


### PR DESCRIPTION
Fix #275.

Replace out of date pypiwin32 dependency with pywin32.

Removed specific version pin in appveyor as well.