### PR TITLE
Give Button a .text attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ CHANGE HISTORY
 
 LATEST
 ------
-- Added ability to accept a name attribute in the Button constructor.
+- Added ability to change a `Button`'s text through a `.text` attribute.
+- Added ability to accept a name attribute in the `Button` constructor.
 - Added ability to detect job pause/resume and force full screen refresh.
 - Added ability to request terminal default colours using `Screen.COLOUR_DEFAULT`.
 - Converted widgets to a sub-package.

--- a/asciimatics/widgets/button.py
+++ b/asciimatics/widgets/button.py
@@ -15,7 +15,7 @@ class Button(Widget):
     on a form).
     """
 
-    __slots__ = ["_text", "_add_box", "_on_click", "_label"]
+    __slots__ = ["_text", "_text_raw", "_add_box", "_on_click", "_label"]
 
     def __init__(self, text, on_click, label=None, add_box=True, name=None, **kwargs):
         """
@@ -28,9 +28,8 @@ class Button(Widget):
         Also see the common keyword arguments in :py:obj:`.Widget`.
         """
         super(Button, self).__init__(name, **kwargs)
-        # We only ever draw the button with borders, so calculate that once now.
-        self._text = "< {} >".format(text) if add_box else text
         self._add_box = add_box
+        self.text = text
         self._on_click = on_click
         self._label = label
 
@@ -77,6 +76,18 @@ class Button(Widget):
 
     def required_height(self, offset, width):
         return 1
+
+    @property
+    def text(self):
+        """
+        The current text for this Button.
+        """
+        return self._text_raw
+
+    @text.setter
+    def text(self, new_text):
+        self._text_raw = str(new_text)
+        self._text = "< {} >".format(new_text) if self._add_box else new_text
 
     @property
     def value(self):

--- a/asciimatics/widgets/button.py
+++ b/asciimatics/widgets/button.py
@@ -86,7 +86,7 @@ class Button(Widget):
 
     @text.setter
     def text(self, new_text):
-        self._text_raw = str(new_text)
+        self._text_raw = new_text
         self._text = "< {} >".format(new_text) if self._add_box else new_text
 
     @property

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -3224,5 +3224,18 @@ class TestWidgets(unittest.TestCase):
         btn = Button("Run", _on_click, name="btn_run")
 
 
+    def test_button_text(self):
+        """
+        Check Button text can be set as an attribute.
+        """
+        def _on_click():
+            pass
+
+        btn = Button("Before", _on_click)
+        self.assertEqual(btn.text, "Before")
+        btn.text = "After"
+        self.assertEqual(btn.text, "After")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
#300

What does this implement/fix?
-----------------------------
A feature request to give Button objects a .text attribute

Any other comments?
-------------------
In the implementation, I created a shadow copy of the text so that retrieving the .text didn't include the chevrons.
