### PR TITLE
Fix typo

### DIFF
--- a/samples/contact_list.py
+++ b/samples/contact_list.py
@@ -11,7 +11,7 @@ import sqlite3
 
 class ContactModel(object):
     def __init__(self):
-        # Create a database in RAM
+        # Create a database in RAM.
         self._db = sqlite3.connect(':memory:')
         self._db.row_factory = sqlite3.Row
 


### PR DESCRIPTION
All comments, except for one, ended with a period (`.`). Now they all do.