### PR TITLE
Change Frame to support scroll bars without a border

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ LATEST
 - Added dynamically sized, animated sprites to ray caster demo.
 - Added fit parameter to DropdownList.
 - Added support for default colours to AnsiTerminalParser
-- BREAKING CHANGE: Frame now supports scroll bars without borders, to have no border and no scroll bar you now need Frame(has_border=False, can_scroll=False)
+- BREAKING VISUAL CHANGE: Frame now supports scroll bars without borders, to have no border and no scroll bar you now need Frame(has_border=False, can_scroll=False)
 
 1.13.0
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ LATEST
 - Added dynamically sized, animated sprites to ray caster demo.
 - Added fit parameter to DropdownList.
 - Added support for default colours to AnsiTerminalParser
+- BREAKING CHANGE: Frame now supports scroll bars without borders, to have no border and no scroll bar you now need Frame(has_border=False, can_scroll=False)
 
 1.13.0
 ------

--- a/asciimatics/widgets/frame.py
+++ b/asciimatics/widgets/frame.py
@@ -39,7 +39,7 @@ class _BorderManager:
 
             self.scroll_bar = _ScrollBar(
                 frame.canvas, frame.palette, frame.canvas.width - 1, scroll_y, scroll_height, 
-                frame.scroll_position, frame.scroll_position, absolute=True
+                frame.get_scroll_pos, frame.set_scroll_pos, absolute=True
             )
 
         self.tl = u"┌" if frame.canvas.unicode_aware else "+"
@@ -64,11 +64,16 @@ class _BorderManager:
         :returns: Tuple containing, x, y, height and width of bounding box
         """
         if self.has_border:
-            x = y = 1
+#            x = y = 1
+            x = 1
+            y = self._frame.canvas.start_line + 1
+
             h = self._frame.canvas.height - 2
             w = self._frame.canvas.width - 2
         else:
-            x = y = 0
+#            x = y = 0
+            x = 0
+            y = self._frame.canvas.start_line
             h = self._frame.canvas.height
             w = self._frame.canvas.width
 
@@ -183,21 +188,7 @@ class Frame(Effect):
         self._theme = None
         self.set_theme("default")
 
-    @property
-    def scroll_position(self):
-        """
-        Get current position for scroll bar.
-        """
-        return self._get_pos()
-
-    @scroll_position.setter
-    def scroll_position(self, pos):
-        """
-        Set current position for scroll bar
-        """
-        self._set_pos(pos)
-
-    def _get_pos(self):
+    def get_scroll_pos(self):
         """
         Get current position for scroll bar.
         """
@@ -205,7 +196,7 @@ class Frame(Effect):
             return 0
         return self._canvas.start_line / (self._max_height - self._canvas.height + 1)
 
-    def _set_pos(self, pos):
+    def set_scroll_pos(self, pos):
         """
         Set current position for scroll bar.
         """
@@ -560,6 +551,28 @@ class Frame(Effect):
         :param h: The height of the location to make visible.
         """
         start_x, start_y, height, width = self._border_mgr.get_rectangle()
+        #if self.has_border:
+        #    x = y = 1
+        #    h = self._frame.canvas.height - 2
+        #    w = self._frame.canvas.width - 2
+        #else:
+        #    x = y = 0
+        #    h = self._frame.canvas.height
+        #    w = self._frame.canvas.width
+
+        #    if self.can_scroll:
+        #        w -= 1
+
+        #if self._border_mgr.has_border:
+        #    start_x = 1
+        #    width = self._canvas.width - 2
+        #    start_y = self._canvas.start_line + 1
+        #    height = self._canvas.height - 2
+        #else:
+        #    start_x = 0
+        #    width = self._canvas.width
+        #    start_y = self._canvas.start_line
+        #    height = self._canvas.height
 
         if ((start_x <= x < start_x + width) and (y >= start_y) and (y + h < start_y + height)):
             # Already OK - quit now.

--- a/asciimatics/widgets/frame.py
+++ b/asciimatics/widgets/frame.py
@@ -64,14 +64,12 @@ class _BorderManager:
         :returns: Tuple containing, x, y, height and width of bounding box
         """
         if self.has_border:
-#            x = y = 1
             x = 1
             y = self._frame.canvas.start_line + 1
 
             h = self._frame.canvas.height - 2
             w = self._frame.canvas.width - 2
         else:
-#            x = y = 0
             x = 0
             y = self._frame.canvas.start_line
             h = self._frame.canvas.height
@@ -551,28 +549,6 @@ class Frame(Effect):
         :param h: The height of the location to make visible.
         """
         start_x, start_y, height, width = self._border_mgr.get_rectangle()
-        #if self.has_border:
-        #    x = y = 1
-        #    h = self._frame.canvas.height - 2
-        #    w = self._frame.canvas.width - 2
-        #else:
-        #    x = y = 0
-        #    h = self._frame.canvas.height
-        #    w = self._frame.canvas.width
-
-        #    if self.can_scroll:
-        #        w -= 1
-
-        #if self._border_mgr.has_border:
-        #    start_x = 1
-        #    width = self._canvas.width - 2
-        #    start_y = self._canvas.start_line + 1
-        #    height = self._canvas.height - 2
-        #else:
-        #    start_x = 0
-        #    width = self._canvas.width
-        #    start_y = self._canvas.start_line
-        #    height = self._canvas.height
 
         if ((start_x <= x < start_x + width) and (y >= start_y) and (y + h < start_y + height)):
             # Already OK - quit now.

--- a/asciimatics/widgets/popupmenu.py
+++ b/asciimatics/widgets/popupmenu.py
@@ -43,7 +43,7 @@ class PopupMenu(Frame):
 
         # Construct the Frame
         super(PopupMenu, self).__init__(
-            screen, h, w, x=x, y=y, has_border=False, is_modal=True, hover_focus=True)
+            screen, h, w, x=x, y=y, has_border=False, can_scroll=False, is_modal=True, hover_focus=True)
 
         # Build the widget to display the time selection.
         layout = Layout([1], fill_frame=True)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,7 @@ coveralls
 git+https://github.com/peterbrittain/appveyor-artifacts.git
 mock
 nose
+prospector
 sphinx
 # Try to resolve dependency clashes on 2.7 systems
 urllib3==1.22

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@ coveralls
 git+https://github.com/peterbrittain/appveyor-artifacts.git
 mock
 nose
-prospector
 sphinx
 # Try to resolve dependency clashes on 2.7 systems
 urllib3==1.22

--- a/samples/frame_borders.py
+++ b/samples/frame_borders.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+from asciimatics.widgets import (Frame, TextBox, Layout, Label, Divider, Text, 
+    Button, PopUpDialog, PopupMenu)
+
+from asciimatics.effects import Background
+from asciimatics.scene import Scene
+from asciimatics.screen import Screen
+from asciimatics.exceptions import (ResizeScreenError, NextScene, 
+    StopApplication, InvalidFields)
+from asciimatics.parsers import AsciimaticsParser
+import logging
+
+# Initial data for the form
+form_data1 = {
+    "BOX1": [str(x) for x in range(1, 15)],
+}
+
+form_data2 = {
+    "BOX2": [str(x) for x in range(16, 30)],
+}
+
+form_data3 = {
+    "BOX3": [str(x) for x in range(31, 45)],
+}
+
+logging.basicConfig(filename="frame_borders.log", level=logging.DEBUG)
+
+
+class TopFrame(Frame):
+    def __init__(self, screen):
+        super(TopFrame, self).__init__(screen,
+                                        int(screen.height // 4),
+                                        screen.width,
+                                        y=0,
+                                        data=form_data1,
+                                        has_border=True,
+                                        can_scroll=True,
+                                        name="Top Form")
+        layout = Layout([1, 18, 1])
+        self.add_layout(layout)
+        layout.add_widget(TextBox(5, label="Box 1:", name="BOX1"), 1)
+        self.fix()
+
+
+class MidFrame(Frame):
+    def __init__(self, screen):
+        super(MidFrame, self).__init__(screen,
+                                        int(screen.height // 4),
+                                        screen.width,
+                                        y=int(screen.height // 4),
+                                        data=form_data2,
+                                        has_border=False,
+                                        can_scroll=True,
+                                        name="Mid Form")
+        layout = Layout([1, 18, 1])
+        self.add_layout(layout)
+        layout.add_widget(TextBox(5, label="Box 2:", name="BOX2"), 1)
+        self.fix()
+
+
+class BottomFrame(Frame):
+    def __init__(self, screen):
+        super(BottomFrame, self).__init__(screen,
+                                        int(screen.height // 2),
+                                        screen.width,
+                                        y=int(screen.height // 2),
+                                        data=form_data3,
+                                        has_border=False,
+                                        can_scroll=False,
+                                        name="Bottom Form")
+        layout = Layout([1, 18, 1])
+        self.add_layout(layout)
+        layout.add_widget(TextBox(5, label="Box 3:", name="BOX3"), 1)
+        layout.add_widget(Divider(height=3), 1)
+
+        layout2 = Layout([1, 1, 1])
+        self.add_layout(layout2)
+        layout2.add_widget(Button("Quit", self._quit), 0)
+        self.fix()
+
+    def _quit(self):
+        popup = PopUpDialog(self._screen, "Are you sure?", ["Yes", "No"],
+                    has_shadow=True, on_close=self._quit_on_yes)
+        self._scene.add_effect(popup)
+
+    @staticmethod
+    def _quit_on_yes(selected):
+        # Yes is the first button
+        if selected == 0:
+            raise StopApplication("User requested exit")
+
+
+def demo(screen, scene):
+    scenes = [Scene([
+        Background(screen),
+        TopFrame(screen),
+        MidFrame(screen),
+        BottomFrame(screen),
+    ], -1)]
+
+    screen.play(scenes, stop_on_resize=True, start_scene=scene, allow_int=True)
+
+
+last_scene = None
+while True:
+    try:
+        Screen.wrapper(demo, catch_interrupt=False, arguments=[last_scene])
+        quit()
+    except ResizeScreenError as e:
+        last_scene = e.scene

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -25,12 +25,13 @@ from asciimatics.strings import ColouredText
 
 
 class TestFrame(Frame):
-    def __init__(self, screen, has_border=True, reduce_cpu=False, label_height=1):
+    def __init__(self, screen, has_border=True, can_scroll=True, reduce_cpu=False, label_height=1):
         super(TestFrame, self).__init__(screen,
                                         screen.height,
                                         screen.width,
                                         name="Test Form",
                                         has_border=has_border,
+                                        can_scroll=can_scroll,
                                         hover_focus=True,
                                         reduce_cpu=reduce_cpu)
         layout = Layout([1, 18, 1])
@@ -184,7 +185,7 @@ class TestFrame3(Frame):
 class TestFrame4(Frame):
     def __init__(self, screen, file_filter=None):
         super(TestFrame4, self).__init__(
-            screen, screen.height, screen.width, has_border=False, name="My Form")
+            screen, screen.height, screen.width, has_border=False, can_scroll=False, name="My Form")
 
         # State tracking for callbacks
         self.selected = None
@@ -430,7 +431,7 @@ class TestWidgets(unittest.TestCase):
         """
         screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
         canvas = Canvas(screen, 10, 40, 0, 0)
-        form = TestFrame(canvas, has_border=False)
+        form = TestFrame(canvas, has_border=False, can_scroll=False)
         form.reset()
 
         # Check initial rendering
@@ -463,6 +464,30 @@ class TestWidgets(unittest.TestCase):
             "              [ ] Field 3               \n" +
             "                                        \n" +
             "  ------------------------------------  \n")
+
+    def test_no_border_can_scroll(self):
+        """
+        Check that a Frame with scroll bar but without border renders
+        """
+        screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
+        canvas = Canvas(screen, 10, 40, 0, 0)
+        form = TestFrame(canvas, has_border=False, can_scroll=True)
+        form.reset()
+
+        # Check initial rendering
+        form.update(0)
+        self.assert_canvas_equals(
+            canvas,
+            " Group 1:                               \n" +
+            " My First                              O\n" +
+            " Box:                                  |\n" +
+            "                                       |\n" +
+            "                                       |\n" +
+            "                                       |\n" +
+            " Text1:                                |\n" +
+            " Text2:                                |\n" +
+            " Text3:                                |\n" +
+            "                                        \n")
 
     def test_form_input(self):
         """
@@ -1015,7 +1040,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 2, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         layout.add_widget(Text("Test"))
@@ -1073,7 +1099,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False, 
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         mc_list = MultiColumnListBox(
             Widget.FILL_FRAME,
@@ -1201,7 +1228,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         mc_list = MultiColumnListBox(
             Widget.FILL_FRAME,
@@ -1247,7 +1275,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         simple_list = ListBox(
             3,
@@ -1322,7 +1351,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         mc_list = MultiColumnListBox(
             3,
@@ -1366,7 +1396,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         text_box = TextBox(1, as_string=True)
@@ -1403,7 +1434,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         text_box = TextBox(5, as_string=True, line_wrap=True)
@@ -1562,7 +1594,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         mc_list = MultiColumnListBox(
             4,
@@ -2631,7 +2664,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 2, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         text = Text("Password", hide_char="*")
@@ -2662,7 +2696,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         text = Text()
@@ -3029,7 +3064,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         text_box = TextBox(3, as_string=True, parser=AsciimaticsParser())
@@ -3071,7 +3107,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         listbox = ListBox(2, [])
@@ -3091,7 +3128,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         listbox = ListBox(2, [], parser=AsciimaticsParser())
@@ -3122,7 +3160,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         text_box = TextBox(3, as_string=True, readonly=True)
@@ -3169,7 +3208,8 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 10, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
+            can_scroll=False)
         layout = Layout([1,1], fill_frame=True)
         form.add_layout(layout)
         for col in range(2):

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1040,8 +1040,7 @@ class TestWidgets(unittest.TestCase):
         canvas = Canvas(screen, 2, 40, 0, 0)
 
         # Create the form we want to test.
-        form = Frame(canvas, canvas.height, canvas.width, has_border=False,
-            can_scroll=False)
+        form = Frame(canvas, canvas.height, canvas.width, has_border=False, can_scroll=False)
         layout = Layout([100], fill_frame=True)
         form.add_layout(layout)
         layout.add_widget(Text("Test"))


### PR DESCRIPTION
Issues fixed by this PR
-----------------------
None

What does this implement/fix?
-----------------------------
Frame can now support a scroll bar without rendering a border. Frame.has_border and Frame.can_scroll are now independent of each other. This is a breaking change: Frame(has_border=False) now needs to be Frame(has_border=False, can_scroll=False) to get the same effect)

Any other comments?
-------------------
Updated Frame.move_to() to use self._canvas for consistency
