### PR TITLE
Add "return widget" to Layout's add_widget() method to make chaining easier

### DIFF
--- a/asciimatics/widgets/layout.py
+++ b/asciimatics/widgets/layout.py
@@ -108,6 +108,8 @@ class Layout(object):
         if widget.name in self._frame.data:
             widget.value = self._frame.data[widget.name]
 
+        return widget
+
     def clear_widgets(self):
         """
         Clear all widgets from this Layout.

--- a/asciimatics/widgets/layout.py
+++ b/asciimatics/widgets/layout.py
@@ -108,6 +108,10 @@ class Layout(object):
         if widget.name in self._frame.data:
             widget.value = self._frame.data[widget.name]
 
+        # Send widget back so you can do a nested declaration in the
+        # add_widget call, e.g.:
+        #
+        # widget = layout.add_widget(Text("thing"), 1)
         return widget
 
     def clear_widgets(self):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,6 @@
 # Tie down version to ensure Image dithering is consistent in UTs
 Pillow == 6.2.2
 coveralls
-git+https://github.com/peterbrittain/appveyor-artifacts.git
 mock
 nose
 sphinx

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -37,8 +37,11 @@ class TestFrame(Frame):
         layout = Layout([1, 18, 1])
         self.add_layout(layout)
         self._reset_button = Button("Reset", self._reset)
-        self.label = Label("Group 1:", height=label_height)
-        layout.add_widget(self.label, 1)
+
+        # Test that layout.add_widget returns the widget
+        self.label = layout.add_widget(
+            Label("Group 1:", height=label_height), 1)
+
         layout.add_widget(TextBox(5,
                                   label="My First Box:",
                                   name="TA",


### PR DESCRIPTION
What does this implement/fix?
-----------------------------
One line change that adds "return widget" to the end of Layout's add_widget() method. This allows doing one-line layout and creation such as:

```
self.my_button = layout.add_widget(Button("My Button"), 1)
```
