### PR TITLE
docs: Fix a few typos

### DIFF
--- a/asciimatics/exceptions.py
+++ b/asciimatics/exceptions.py
@@ -82,7 +82,7 @@ class NextScene(Exception):
 class InvalidFields(Exception):
     """
     When saving data from a Frame, you can ask the Frame to validate the data
-    before saving.  This is the exception that gets thrwn if any invalid datd
+    before saving.  This is the exception that gets thrwn if any invalid data
     is found.
     """
 

--- a/asciimatics/parsers.py
+++ b/asciimatics/parsers.py
@@ -231,7 +231,7 @@ class AnsiTerminalParser(Parser):
                                 break
                             in_set_mode = False
                         elif in_index_mode:
-                            # We are processing a 5;n sequence for colour indeces
+                            # We are processing a 5;n sequence for colour indices
                             st.attributes[attribute_index] = parameter
                             in_index_mode = False
                         elif in_rgb_mode:

--- a/asciimatics/renderers/players.py
+++ b/asciimatics/renderers/players.py
@@ -211,7 +211,7 @@ class AsciinemaPlayer(AbstractScreenPlayer):
         if header["version"] != 2:
             raise RuntimeError("Unsupported file format")
 
-        # Use file details if not overriden by constructor params.
+        # Use file details if not overridden by constructor params.
         height = height if height else header["height"]
         width = width if width else header["width"]
 

--- a/asciimatics/widgets/textbox.py
+++ b/asciimatics/widgets/textbox.py
@@ -272,7 +272,7 @@ class TextBox(Widget):
         The text as should be formatted on the screen.
 
         This is an array of tuples of the form (text, value line, value column offset) where
-        the line and column offsets are indeces into the value (not displayed glyph coordinates).
+        the line and column offsets are indices into the value (not displayed glyph coordinates).
         """
         if self._reflowed_text_cache is None:
             if self._line_wrap:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -94,7 +94,7 @@ These should always work for you as background and foreground colours (even on W
 systems you can also use the attributes (see later) to double the number of foreground colours.
 
 If you have a display capable of handling more than these (e.g. 256 colour xterm) you can use the
-indexes of the colours for that display directly instead.  For a full list of the colour indeces,
+indexes of the colours for that display directly instead.  For a full list of the colour indices,
 look `here <https://askubuntu.com/a/821163/1014276>`__.
 
 When creating effects that use these extra colours, it is recommended that you also support a
@@ -235,7 +235,7 @@ In a little more detail, you can read the Screen size (at the time of creation) 
 this by calling the :py:meth:`.has_resized` method.  In addition, you can tell the Screen to throw
 an exception if this happens while you are playing a Scene by specifying ``stop_on_resize=True``.
 
-Once you have detetected that the screen size has changed using one of the options above, you can
+Once you have detected that the screen size has changed using one of the options above, you can
 either decide to carry on with the current Screen or throw it away and create a new one (by simply
 creating a new Screen object). If you do the latter, you will typically need to recreate your
 associated Scenes and Effects to run inside the new boundaries.  See the bars.py demo as a sample


### PR DESCRIPTION
There are small typos in:
- asciimatics/exceptions.py
- asciimatics/parsers.py
- asciimatics/renderers/players.py
- asciimatics/widgets/textbox.py
- doc/source/io.rst

Fixes:
- Should read `indices` rather than `indeces`.
- Should read `overridden` rather than `overriden`.
- Should read `detected` rather than `detetected`.
- Should read `data` rather than `datd`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md