### PR TITLE
Gaplayout

### DIFF
--- a/asciimatics/widgets/__init__.py
+++ b/asciimatics/widgets/__init__.py
@@ -15,6 +15,7 @@ from asciimatics.widgets.multicolumnlistbox import MultiColumnListBox
 from asciimatics.widgets.popupdialog import PopUpDialog
 from asciimatics.widgets.popupmenu import PopupMenu
 from asciimatics.widgets.radiobuttons import RadioButtons
+from asciimatics.widgets.readbox import ReadBox
 from asciimatics.widgets.textbox import TextBox
 from asciimatics.widgets.text import Text
 from asciimatics.widgets.timepicker import TimePicker

--- a/asciimatics/widgets/layout.py
+++ b/asciimatics/widgets/layout.py
@@ -37,13 +37,14 @@ class Layout(object):
     """
 
     __slots__ = ["_column_sizes", "_columns", "_frame", "_has_focus", "_live_col", "_live_widget",
-                 "_fill_frame"]
+                 "_fill_frame", "_gutter"]
 
-    def __init__(self, columns, fill_frame=False):
+    def __init__(self, columns, fill_frame=False, gutter=0):
         """
         :param columns: A list of numbers specifying the width of each column in this layout.
         :param fill_frame: Whether this Layout should attempt to fill the rest of the Frame.
             Defaults to False.
+        :param gutter: gutter space between columns specified in characters, defaults to 0
 
         The Layout will automatically normalize the units used for the columns, e.g. converting
         [2, 6, 2] to [20%, 60%, 20%] of the available canvas.
@@ -56,6 +57,7 @@ class Layout(object):
         self._live_col = 0
         self._live_widget = -1
         self._fill_frame = fill_frame
+        self._gutter = gutter
 
     @property
     def fill_frame(self):
@@ -183,8 +185,9 @@ class Layout(object):
         :param max_height: Max height to allow this layout.
         :returns: The next line to be used for any further Layouts.
         """
+        total_gutter = self._gutter * (len(self._columns) - 1)
         x = start_x
-        width = max_width
+        width = max_width - total_gutter
         y = w = 0
         max_y = start_y
         string_len = wcswidth if self._frame.canvas.unicode_aware else len
@@ -232,9 +235,9 @@ class Layout(object):
             # Note space used by this column.
             dimensions[i].height = y
 
-            # Update tracking variables fpr the next column.
+            # Update tracking variables for the next column.
             max_y = max(max_y, y)
-            x += w
+            x += w + self._gutter
 
         # Finally check whether the Layout is allowed to expand.
         if self.fill_frame:

--- a/asciimatics/widgets/readbox.py
+++ b/asciimatics/widgets/readbox.py
@@ -1,0 +1,392 @@
+# -*- coding: utf-8 -*-
+"""This module implements a multi line read-only text box"""
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import chr
+from builtins import str
+from copy import copy
+from logging import getLogger
+from asciimatics.event import KeyboardEvent, MouseEvent
+from asciimatics.screen import Screen
+from asciimatics.strings import ColouredText
+from asciimatics.widgets.widget import Widget
+from asciimatics.widgets.utilities import _find_min_start, _enforce_width, _get_offset
+
+# Logging
+logger = getLogger(__name__)
+
+
+class ReadBox(Widget):
+    """
+    A ReadBox is a widget for multi-line read-only text viewing.
+
+    It consists of a framed box with option label.
+    """
+
+    __slots__ = ["_label", "_required_height", "_line_wrap", "_parser",
+        "_line_cursor", "_auto_scroll", "_longest", "_viewport_row",
+        "_viewport_col", "_cursor_colour", "_content", "_content_changed",
+        "_cursor_row"]
+
+    def __init__(self, height, label=None, name=None, as_string=False,
+            line_wrap=False, parser=None, on_change=None, **kwargs):
+        """
+        :param height: The required number of input lines for this ReadBox.
+        :param label: An optional label for the widget.
+        :param name: The name for the ReadBox.
+        :param line_wrap: Whether to wrap at the end of the line.
+        :param parser: Optional parser to colour text.
+
+        Also see the common keyword arguments in :py:obj:`.Widget`.
+        """
+        super(ReadBox, self).__init__(name, **kwargs)
+        self._label = label
+
+        self._viewport_row = 0
+        self._viewport_col = 0
+
+        self._cursor_row = 0
+
+        self._required_height = height
+        self._line_wrap = line_wrap
+        self._parser = parser
+        self._line_cursor = True
+        self._cursor_colour = Screen.COLOUR_WHITE
+        self._auto_scroll = False
+
+        self._content = []
+        self._content_changed = True
+        self._longest = 0
+
+    def update(self, frame_no):
+        if self._content_changed:
+            self._generate_content()
+
+        self._draw_label()
+
+        # Clear out the existing box content
+        (colour, attr, background) = self._pick_colours("readonly")
+        self._frame.canvas.clear_buffer(colour, attr, background,
+            self._x + self._offset, self._y, self.width, self._h)
+
+        # Loop through the content in the view port
+        x = self._viewport_row
+        h = self._viewport_row + self._h
+        bg = background
+        limit = self._w - self._offset
+
+        #logger.debug("******* Updating Viewport")
+        #for item in self._content[x:h]:
+        #    logger.debug("%s", item)
+
+        for index, (wrap_count, text) in enumerate(self._content[x:h]):
+            position = self._viewport_row + index
+            bg = background
+            virtual_cursor = position
+            if wrap_count > 0:
+                virtual_cursor = position - wrap_count + 1
+
+            if self._line_cursor and self._cursor_row == virtual_cursor \
+                    and self._has_focus:
+                #logger.debug("   CURSOR cx=%d vx=%d p=%d wc=%d %s",
+                #    self._cursor_row, x, position, wrap_count, text)
+                bg = self._cursor_colour
+
+            # Clip the text to the width of the view port
+            y = self._viewport_col
+            paint_text = text[y:y+limit]
+            colour_map = getattr(paint_text, "colour_map", None)
+
+            self._frame.canvas.paint(
+                paint_text,
+                self._x + self._offset,
+                self._y + index,
+                colour, attr, bg,
+                colour_map=colour_map)
+
+    def reset(self):
+        # Reset to original data and move to end of the text.
+        self._viewport_row = 0
+        self._viewport_col = 0
+
+        self._cursor_row = 0
+
+        if self._auto_scroll and self._content:
+            # Scroll to the bottom
+            self._change_line( len(self._content) )
+
+    def _cursor_to_line(self, num):
+        """Moves the cursor to the given line. Moves the view port if
+        required.
+        """
+        #logger.debug("**** to line num=%d cr=%d vr=%d", num,
+        #    self._cursor_row, self._viewport_row)
+        if num < 0:
+            self._cursor_row = 0
+        elif num >= len(self._content):
+            self._cursor_row = len(self._content) - 1
+        else:
+            self._cursor_row = num
+
+        logger.debug("   adjusted cursor cr=%d", self._cursor_row)
+
+        # Adjust cursor for wrapped rows
+        if self._line_wrap and self._content[self._cursor_row][0] > 1:
+            # Cursor moved to a wrapped line, adjust to the first of the
+            # wrapped lines
+            self._cursor_row -= self._content[self._cursor_row][0] - 1
+
+            logger.debug("   wrap moved cr=%d", self._cursor_row)
+
+        # Cursor has been moved, adjust the view port if needed
+        if self._cursor_row < self._viewport_row:
+            self._viewport_row = self._cursor_row
+        elif self._cursor_row > self._viewport_row + self._h:
+            self._viewport_row = self._cursor_row - self._h
+
+        #logger.debug("   => outcome num=%d cr=%d vr=%d", num,
+        #    self._cursor_row, self._viewport_row)
+
+    def _change_line(self, delta):
+        """
+        Move the cursor up/down the specified number of lines.
+
+        :param delta: The number of lines to move (-ve is up, +ve is down).
+        """
+        # Ensure new line is within limits
+        self._cursor_row = min(max(0, self._cursor_row + delta),
+            len(self._content) - 1)
+
+        # If the cursor is on a wrapped line, position it to treat the wrapped
+        # lines as a single unit
+        if self._line_wrap and self._content[self._cursor_row][0] >= 1:
+            if delta < 0 :
+                # When moving up, cursor position is top of wrapped group
+                self._cursor_row -= self._content[self._cursor_row][0] - 1
+            else:
+                # When moving down, skip any wrapped lines
+                while self._content[self._cursor_row][0] > 1:
+                    self._cursor_row += 1
+                    if self._content[self._cursor_row][0] == 1:
+                        # Hit two sets of wrapped lines in a row: stop
+                        break
+
+        # Check if the view port has moved
+        if self._cursor_row < self._viewport_row:
+            self._viewport_row = self._cursor_row
+            return
+
+        if self._cursor_row > self._viewport_row + self._h - 1:
+            self._viewport_row = self._cursor_row - self._h + 1
+
+    def _change_vscroll(self, delta):
+        """
+        Move the scroll port up/down the specified number of lines.
+
+        :param delta: The number of lines to move (-ve is up, +ve is down).
+        """
+        self._viewport_row += delta
+
+        if self._viewport_row < 0:
+            self._viewport_row = 0
+        elif self._viewport_row + self._h > len(self._content):
+            self._viewport_row = len(self._content) - self._h
+
+    def _change_hscroll(self, delta):
+        """
+        Move the scroll port left or right the specified number of columns.
+
+        :param delta: The number of lines to move (-ve is left, +ve is right).
+        """
+        logger.debug("b hscroll y=%d d=%d", self._viewport_col, delta)
+
+        self._viewport_col += delta
+        if self._viewport_col < 0:
+            self._viewport_col = 0
+            return
+
+        farthest = self._longest - (self._w - self._offset)
+        logger.debug("  => farthest=%d w=%d l=%d o=%d", farthest, self._w,
+            self._longest, self._offset)
+        if self._viewport_col > farthest:
+            self._viewport_col = farthest
+
+    def _keyboard_event(self, event):
+        if event.key_code == Screen.KEY_PAGE_UP:
+            self._change_line(-self._h)
+        elif event.key_code == Screen.KEY_PAGE_DOWN:
+            self._change_line(self._h)
+        elif event.key_code == Screen.KEY_UP:
+            if self._line_cursor:
+                self._change_line(-1)
+            else:
+                self._change_vscroll(-1)
+        elif event.key_code == Screen.KEY_DOWN:
+            if self._line_cursor:
+                self._change_line(1)
+            else:
+                self._change_vscroll(1)
+        elif event.key_code == Screen.KEY_LEFT and not self._line_wrap:
+            self._change_hscroll(-1)
+        elif event.key_code == Screen.KEY_RIGHT and not self._line_wrap:
+            self._change_hscroll(1)
+        elif event.key_code == Screen.KEY_HOME:
+            # Go to the top of the view port
+            self._change_line( -1 * len(self._content) )
+        elif event.key_code == Screen.KEY_END:
+            # Go to the bottom of the view port
+            self._change_line( len(self._content) )
+        else:
+            # Ignore any other key press.
+            return event
+
+        # Event was handled
+        return None
+
+    def _mouse_event(self, event):
+        # Mouse event - rebase coordinates to Frame context.
+        if event.buttons != 0:
+            if self.is_mouse_over(event, include_label=False):
+                clicked_line = event.y - self._y + self._viewport_row
+                self._cursor_to_line(clicked_line)
+                return None
+
+        # Ignore other mouse events.
+        return event
+
+    def process_event(self, event):
+        if isinstance(event, KeyboardEvent):
+            result = self._keyboard_event(event)
+        elif isinstance(event, MouseEvent):
+            result = self._mouse_event(event)
+        else:
+            # Ignore other events
+            return event
+
+        return result
+
+    def required_height(self, offset, width):
+        return self._required_height
+
+    @property
+    def line_cursor(self):
+        """
+        Set to True to show the line cursor.  Defaults to False.
+        """
+        return self._hide_cursor
+
+    @line_cursor.setter
+    def line_cursor(self, new_value):
+        self._line_cursor = new_value
+
+    @property
+    def auto_scroll(self):
+        """
+        When set to True the ReadBox will scroll to the bottom when created or
+        next text is added. When set to False, the current scroll position
+        will remain even if the contents are changed.
+
+        Defaults to True.
+        """
+        return self._auto_scroll
+
+    @auto_scroll.setter
+    def auto_scroll(self, new_value):
+        self._auto_scroll = new_value
+
+    @property
+    def cursor_colour(self):
+        """The highlighting line cursor's colour. Defaults to white."""
+        return self._cursor_colour
+
+    @cursor_colour.setter
+    def cursor_colour(self, colour):
+        """The highlighting line cursor's colour. Defaults to white."""
+        self._cursor_colour = colour
+
+
+    @property
+    def value(self):
+        """
+        The current value for this ReadBox as a list of strings.
+        """
+        if self._value is None:
+            self._value = [""]
+        return self._value
+
+    @value.setter
+    def value(self, new_value):
+        self._content_changed = True
+        self._value = new_value
+        if new_value is None:
+            return
+
+        self.reset()
+
+    def _generate_content(self):
+        # Handle text colour parsing and determine longest line
+        self._content = []
+
+        lines = []
+        self._longest = 0
+        last_colour = None
+        for line in self._value:
+            # Parse colour escapes from text
+            if self._parser and not hasattr(line, "raw_text"):
+                line = ColouredText(line, self._parser, colour=last_colour)
+                last_colour = line.last_colour
+
+            length = self.string_len(str(line))
+            if length > self._longest:
+                self._longest = length
+
+            lines.append(line)
+
+        if self._line_wrap:
+            # If wrapping lines, each line should be the width of the window
+            self._longest = self._w - self._offset
+
+        # Convert to the internal format:
+        #
+        #   (wrap, text)
+        #
+        # wrap: bool, True if this is part of a wrapped line
+        # text: parsed text
+        limit = self._w - self._offset
+        for line in lines:
+            length = self.string_len(str(line))
+
+            if self._line_wrap and length > limit:
+                # Wrapping, deconstruct the line into its parts
+                wrap_count = 1
+                while self.string_len(str(line)) >= limit:
+                    sub_string = _enforce_width(line, limit,
+                        self._frame.canvas.unicode_aware)
+
+                    length = self.string_len(str(sub_string))
+                    sub_string += ' ' * (self._longest - length)
+
+                    self._content.append( (wrap_count, sub_string) )
+                    line = line[len(sub_string):]
+
+                    wrap_count += 1
+
+                length = self.string_len(str(line))
+                line += ' ' * (self._longest - length)
+                self._content.append( (wrap_count, line) )
+            else:
+                # Not wrapping lines, pad to longest, then store
+                length = self.string_len(str(line))
+                line += ' ' * (self._longest - length)
+                self._content.append( (0, line) )
+
+        if self._auto_scroll and self._content:
+            # Scroll to the bottom
+            self._change_line( len(self._content) )
+
+        #logger.debug("**** Content built")
+        #for wc, text in self._content:
+        #    logger.debug(" %3d *%s*", wc, text)
+        self._content_changed = False

--- a/samples/form_readbox.py
+++ b/samples/form_readbox.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+from asciimatics.widgets import Frame, Layout, Label, Divider, Button, ReadBox
+from asciimatics.effects import Background
+from asciimatics.event import MouseEvent
+from asciimatics.scene import Scene
+from asciimatics.screen import Screen
+from asciimatics.exceptions import ResizeScreenError, NextScene, StopApplication, InvalidFields
+from asciimatics.parsers import AsciimaticsParser
+import sys
+import re
+import datetime
+import logging
+
+# Test data
+tree = r"""
+       ${3,1}*
+${2}      / \
+${2}     /${1}o${2}  \
+${2}    /_   _\ ${1}
+This is the first wrapping line, wrap wrap wrap, and then wrap some more.  These are the Daves I know I know, these are the Daves I know
+123456789 123456789 123456789 123456789 123456789abcdefgh
+${2}     /   \${4}b
+${2}    /     \
+${2}   /   ${1}o${2}   \
+${2}  /__     __\
+  ${1}d${2} / ${4}o${2}   \
+${2}   /       \
+${2}  / ${4}o     ${1}o${2}.\
+${2} /___________\
+      ${3}|||
+      ${3}|||
+
+This is a very long line that goes on and on, it might wrap for you
+""".split("\n")
+
+# Initial data for the form
+form_data = {
+    "TA": tree,
+}
+
+logging.basicConfig(filename="debug.log", level=logging.DEBUG)
+
+
+class DemoFrame(Frame):
+    def __init__(self, screen):
+        super(DemoFrame, self).__init__(screen,
+                                        int(screen.height * 2 // 3),
+                                        int(screen.width * 2 // 3),
+                                        data=form_data,
+                                        has_shadow=True,
+                                        name="My Form")
+        layout = Layout([1, 18, 1])
+        self.add_layout(layout)
+        layout.add_widget(Label("Thing"), 1)
+
+        layout.add_widget(ReadBox(15,
+                                  label="ReadBox:",
+                                  name="TA",
+                                  parser=AsciimaticsParser(),
+                                  line_wrap=True), 1)
+        layout.add_widget(Divider(height=3), 1)
+
+        layout2 = Layout([1, 1, 1])
+        self.add_layout(layout2)
+        layout2.add_widget(Button("Quit", self._quit), 2)
+        self.fix()
+
+    def _quit(self):
+        raise StopApplication("User requested exit")
+
+
+def demo(screen, scene):
+    screen.play([Scene([
+        Background(screen),
+        DemoFrame(screen)
+    ], -1)], stop_on_resize=True, start_scene=scene, allow_int=True)
+
+
+last_scene = None
+while True:
+    try:
+        Screen.wrapper(demo, catch_interrupt=False, arguments=[last_scene])
+        sys.exit(0)
+    except ResizeScreenError as e:
+        last_scene = e.scene

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -3569,15 +3569,6 @@ class TestWidgets(unittest.TestCase):
         for effect in scene.effects:
             effect.update(0)
 
-        print("**********")
-        output = ""
-        for y in range(canvas.height):
-            for x in range(canvas.width):
-                char, _, _, _ = canvas.get_from(x, y)
-                output += chr(char)
-            output += "\n"
-        print(output)
-        print("**********")
         self.assert_canvas_equals(
             canvas,
             "+--------------------------------------+\n" +

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -256,16 +256,20 @@ class TestWidgets(unittest.TestCase):
         self.maxDiff = None
         self.epoch_date = str(date.fromtimestamp(0))
 
-    def assert_canvas_equals(self, canvas, expected):
-        """
-        Assert output to canvas is as expected.
-        """
+    def _canvas_to_string(self, canvas):
         output = ""
         for y in range(canvas.height):
             for x in range(canvas.width):
                 char, _, _, _ = canvas.get_from(x, y)
                 output += chr(char)
             output += "\n"
+        return output
+
+    def assert_canvas_equals(self, canvas, expected):
+        """
+        Assert output to canvas is as expected.
+        """
+        output = self._canvas_to_string(canvas)
         self.assertEqual(output, expected)
 
     @staticmethod
@@ -3530,6 +3534,62 @@ class TestWidgets(unittest.TestCase):
             "|                                      |\n" +
             "+--------------------------------------+\n")
 
+    def test_layout_gutters(self):
+        """
+        Validate that the gutters parameter works for Layouts
+        """
+        # Now set up the Frame ready for testing
+        screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
+        scene = Scene([], duration=-1)
+        canvas = Canvas(screen, 10, 40, 0, 0)
+        form = Frame(canvas, canvas.height, canvas.width)
+        layout = Layout([18, 4, 18], gutter=3)
+        form.add_layout(layout)
+
+        #       0
+        text = "ABCDEFGHIJKLMNOP"
+
+        box1 = TextBox(1)
+        box1.value = [text]
+        layout.add_widget(box1, 0)
+
+        box2 = TextBox(1)
+        box2.value = [text]
+        layout.add_widget(box2, 1)
+
+        box3 = TextBox(1)
+        box3.value = [text]
+        layout.add_widget(box3, 2)
+
+        form.fix()
+        scene.add_effect(form)
+        scene.reset()
+
+        # Check that the frame is rendered correctly.
+        for effect in scene.effects:
+            effect.update(0)
+
+        print("**********")
+        output = ""
+        for y in range(canvas.height):
+            for x in range(canvas.width):
+                char, _, _, _ = canvas.get_from(x, y)
+                output += chr(char)
+            output += "\n"
+        print(output)
+        print("**********")
+        self.assert_canvas_equals(
+            canvas,
+            "+--------------------------------------+\n" +
+            "|DEFGHIJKLMNOP    OP    DEFGHIJKLMNOP  |\n" +
+            "|                                      O\n" +
+            "|                                      |\n" +
+            "|                                      |\n" +
+            "|                                      |\n" +
+            "|                                      |\n" +
+            "|                                      |\n" +
+            "|                                      |\n" +
+            "+--------------------------------------+\n")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
What does this implement/fix?
-----------------------------
Adds ability to specify a gutter between columns in the Layout object

Any other comments?
-------------------
Bunch of stuff:

* The reason I built this was because my custom widget was taking up the entire column. I'm not sure if this is best practice or not. I noticed when I built the test cases using a TextBox, that the default layout was already leaving a single character gap between the columns... which I suspect was being put there by the TextBox itself? Adding a gutter parm of 3 meant the actual gap between the columns becomes 4. Not sure what is the best approach here, could be just that my own widget really had a bug in it, and in that case spec'ing "gutter=3" should turn into an extra 2 space?
* I went with "gutter" rather than "gap" as "gap" is used internally in the comments and I didn't want it to be confused
* I did a small re-factor on the assert_canvas_equal() helper function so that the canvas -> text was in its own function. It makes it easier to print the result to the screen when you're trying to figure out what is going on
* nosetests appear to be failing with Python 3.11, I down switched to Python 3.9. Something to do with the fact that they moved the Collections.abc.Callable class
* The test for the image renderer is failing, but I suspect that's a Pillow version thing. I was unable to install the pinned version of Pillow due to some weirdness with zlib being not found even though it was actually there. I double checked and none of the code I touched is invoked by that test, so I'm assuming it wasn't my fault :)
* I see the occasional comment in the code about the "2.0" version, you going to drop Python 2.7 when you go there?
