### PR TITLE
Add speed parameter to Sprite effect

### DIFF
--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -619,7 +619,7 @@ class Sprite(Effect):
     """
 
     def __init__(self, screen, renderer_dict, path, colour=Screen.COLOUR_WHITE,
-                 clear=True, **kwargs):
+                 clear=True, speed=2, **kwargs):
         """
         :param screen: The Screen being used for the Scene.
         :param renderer_dict: A dictionary of Renderers to use for displaying
@@ -627,6 +627,7 @@ class Sprite(Effect):
         :param path: The Path for the Sprite to follow.
         :param colour: The colour to use to render the Sprite.
         :param clear: Whether to clear out old images or leave a trail.
+        :param speed: The refresh rate in frames between refreshes.
 
         Also see the common keyword arguments in :py:obj:`.Effect`.
         """
@@ -644,6 +645,8 @@ class Sprite(Effect):
         self._dir_x = None
         self._dir_y = None
         self._old_direction = None
+        self._speed = speed
+        self._frame_no = 0
         self.reset()
 
     def reset(self):
@@ -685,7 +688,8 @@ class Sprite(Effect):
             return True
 
     def _update(self, frame_no):
-        if frame_no % 2 == 0:
+        self._frame_no = frame_no
+        if self._speed == 0 or frame_no % self._speed == 0:
             # Blank out the old sprite if moved.
             if (self._clear and
                     self._old_x is not None and self._old_y is not None):

--- a/asciimatics/effects.py
+++ b/asciimatics/effects.py
@@ -646,7 +646,6 @@ class Sprite(Effect):
         self._dir_y = None
         self._old_direction = None
         self._speed = speed
-        self._frame_no = 0
         self.reset()
 
     def reset(self):
@@ -688,7 +687,6 @@ class Sprite(Effect):
             return True
 
     def _update(self, frame_no):
-        self._frame_no = frame_no
         if self._speed == 0 or frame_no % self._speed == 0:
             # Blank out the old sprite if moved.
             if (self._clear and

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -6,7 +6,7 @@ from random import randint
 import os
 import sys
 from asciimatics.effects import Print, Cycle, BannerText, Mirage, Scroll, \
-    Stars, Matrix, Snow, Wipe, Clock, Cog, RandomNoise, Julia
+    Stars, Matrix, Snow, Wipe, Clock, Cog, RandomNoise, Julia, Sprite
 from asciimatics.paths import Path
 from asciimatics.renderers import FigletText, StaticRenderer
 from asciimatics.scene import Scene
@@ -402,6 +402,34 @@ class TestEffects(unittest.TestCase):
         self.assertEqual(effect.stop_frame, 0)
 
         # Static paths should pay no attention to events.
+        event = object()
+        self.assertEqual(event, effect.process_event(event))
+
+    def test_sprite_speed(self):
+        """
+        Check that Sprites speed parameter .
+        """
+        # Check that sprite only redraws on specified rate.
+        screen = MagicMock(spec=Screen, colours=8, unicode_aware=False)
+        path = Path()
+        path.jump_to(10, 5)
+        effect = Sprite(
+            screen,
+            renderer_dict={
+                "default": StaticRenderer(images=["X"])
+            },
+            path=path)
+        effect.reset()
+        effect.update(0)
+        screen.paint.assert_called_with('X', 10, 5, 7, colour_map=[(None, None, None)])
+        screen.paint.reset_mock()
+        effect.update(1)
+        screen.paint.assert_not_called()
+
+        # Check there is no stop frame by default.
+        self.assertEqual(effect.stop_frame, 0)
+
+        # This effect should ignore events.
         event = object()
         self.assertEqual(event, effect.process_event(event))
 


### PR DESCRIPTION
# Thanks for taking the time to contibute to this project.  You are a star!

Issues fixed by this PR
-----------------------
`Sprite` can't be drawn at frame one 

What does this implement/fix?
-----------------------------
It implements speed parameter on `Sprite` just like it's done on the `Print` effect. Now we can draw at frame one using `speed=0` and also have better control on frame rate on sprite. 