### PR TITLE
Improve Unicode support with grapheme clusters

### DIFF
--- a/asciimatics/renderers/base.py
+++ b/asciimatics/renderers/base.py
@@ -5,9 +5,14 @@ This module provides common code for all Renderers.
 from abc import ABCMeta, abstractmethod
 import re
 from typing import Callable, List, Optional, Tuple, Iterable
-from wcwidth.wcwidth import wcswidth
+from wcwidth import wcswidth
 from asciimatics.screen import Screen, TemporaryCanvas
 from asciimatics.constants import COLOUR_REGEX
+
+#: Type alias for colour tuples (foreground, attribute, background)
+Colour = Tuple[Optional[int], Optional[int], Optional[int]]
+#: Type alias for rendered text return type (text lines, colour map)
+RenderedText = Tuple[List[str], List[List[Colour]]]
 
 #: Attribute conversion table for the ${c,a} form of attributes for
 #: :py:obj:`~.Screen.paint`.
@@ -47,7 +52,7 @@ class Renderer(metaclass=ABCMeta):
     @property
     @abstractmethod
     def rendered_text(
-            self) -> Tuple[List[str], List[List[Tuple[Optional[int], Optional[int], Optional[int]]]]]:
+            self) -> RenderedText:
         """
         :return: The next image and colour map in the sequence as a tuple.
         """
@@ -156,7 +161,7 @@ class StaticRenderer(Renderer):
 
     @property
     def rendered_text(
-            self) -> Tuple[List[str], List[List[Tuple[Optional[int], Optional[int], Optional[int]]]]]:
+            self) -> RenderedText:
         """
         :return: The next image and colour map in the sequence as a tuple.
         """
@@ -253,7 +258,7 @@ class DynamicRenderer(Renderer, metaclass=ABCMeta):
         return self._canvas.colour_map
 
     @abstractmethod
-    def _render_now(self) -> Tuple[List[str], List[List[Tuple[Optional[int], Optional[int], Optional[int]]]]]:
+    def _render_now(self) -> RenderedText:
         """
         Common method to render the latest image.
 
@@ -264,7 +269,7 @@ class DynamicRenderer(Renderer, metaclass=ABCMeta):
     @abstractmethod
     def _render_all(
             self
-    ) -> Iterable[Tuple[List[str], List[List[Tuple[Optional[int], Optional[int], Optional[int]]]]]]:
+    ) -> Iterable[RenderedText]:
         """
         Generate all output.
 
@@ -276,12 +281,13 @@ class DynamicRenderer(Renderer, metaclass=ABCMeta):
 
     @property
     def images(self) -> Iterable[List[str]]:
-        # Attempt to get all images.  Note that many are genuinely dynamic and so will only return one.
+        # Attempt to get all images.  Note that many are genuinely dynamic
+        # and so will only return one.
         return [x[0] for x in self._render_all()]
 
     @property
     def rendered_text(
-            self) -> Tuple[List[str], List[List[Tuple[Optional[int], Optional[int], Optional[int]]]]]:
+            self) -> RenderedText:
         if self._must_clear:
             self._clear()
         return self._render_now()

--- a/asciimatics/renderers/speechbubble.py
+++ b/asciimatics/renderers/speechbubble.py
@@ -2,7 +2,7 @@
 This module implements a speech-bubble effect renderer.
 """
 from typing import Optional, Union
-from wcwidth.wcwidth import wcswidth
+from wcwidth import wcswidth, ljust
 from asciimatics.renderers.base import StaticRenderer, Renderer
 
 
@@ -25,14 +25,12 @@ class SpeechBubble(StaticRenderer):
             if uni:
                 bubble = "╭─" + "─" * max_len + "─╮\n"
                 for line in text_list:
-                    filler = " " * (max_len - len(line))
-                    bubble += "│ " + line + filler + " │\n"
+                    bubble += "│ " + ljust(line, max_len) + " │\n"
                 bubble += "╰─" + "─" * max_len + "─╯"
             else:
                 bubble = ".-" + "-" * max_len + "-.\n"
                 for line in text_list:
-                    filler = " " * (max_len - len(line))
-                    bubble += "| " + line + filler + " |\n"
+                    bubble += "| " + ljust(line, max_len) + " |\n"
                 bubble += "`-" + "-" * max_len + "-`"
             if tail == "L":
                 bubble += "\n"

--- a/asciimatics/widgets/utilities.py
+++ b/asciimatics/widgets/utilities.py
@@ -5,7 +5,7 @@ from math import sqrt
 from collections import defaultdict
 from functools import lru_cache
 from typing import TYPE_CHECKING, List, Tuple, Optional, Union
-from wcwidth import wcswidth, wcwidth
+from wcwidth import wcswidth, iter_graphemes, wrap as wcwidth_wrap
 from asciimatics.screen import Screen
 if TYPE_CHECKING:
     from asciimatics.widgets.widget import Widget
@@ -123,7 +123,8 @@ def _enforce_width(text: Union[str, ColouredText],
     :param split_on_words: Whether to respect word boundaries when splitting.
     :return: The resulting truncated text
     """
-    return _enforce_width_ext(text, width, unicode_aware=unicode_aware, split_on_words=split_on_words)[0]
+    return _enforce_width_ext(
+        text, width, unicode_aware=unicode_aware, split_on_words=split_on_words)[0]
 
 
 def _enforce_width_ext(text: Union[str, ColouredText],
@@ -132,7 +133,7 @@ def _enforce_width_ext(text: Union[str, ColouredText],
                        split_on_words: bool = False) -> Tuple[Union[str, ColouredText], bool]:
     """
     Enforce a displayed piece of text to be a certain number of cells wide.  This takes into
-    account double-width characters used in CJK languages.
+    account double-width characters used in CJK languages and grapheme clusters.
 
     :param text: The text to be truncated
     :param width: The screen cell width to enforce
@@ -148,20 +149,24 @@ def _enforce_width_ext(text: Union[str, ColouredText],
     # Can still optimize performance if we are not handling unicode characters.
     if unicode_aware or split_on_words:
         size = 0
-        last_space = 9999999999
-        for i, char in enumerate(str(text)):
-            c_width = wcwidth(char) if ord(char) >= 256 else 1
-            if split_on_words and char in (" ", "\t"):
-                last_space = i + 1
-            if size + c_width > width:
-                return text[0:min(i, last_space)], True
-            size += c_width
+        pos = 0
+        last_space_pos = 9999999999
+        text_str = str(text)
+        for grapheme in iter_graphemes(text_str):
+            g_width = wcswidth(grapheme)
+            if split_on_words and grapheme in (" ", "\t"):
+                last_space_pos = pos + len(grapheme)
+            if size + g_width > width:
+                return text[0:min(pos, last_space_pos)], True
+            size += g_width
+            pos += len(grapheme)
     elif len(text) + 1 > width:
         return text[0:width], True
     return text, False
 
 
-def _find_min_start(text: str, max_width: int, unicode_aware: bool = True, at_end: bool = False) -> int:
+def _find_min_start(text: str, max_width: int, unicode_aware: bool = True,
+                    at_end: bool = False) -> int:
     """
     Find the starting point in the string that will reduce it to be less than or equal to the
     specified width when displayed on screen.
@@ -176,24 +181,29 @@ def _find_min_start(text: str, max_width: int, unicode_aware: bool = True, at_en
     if 2 * len(text) < max_width:
         return 0
 
-    # OK - do it the hard way...
+    # OK - do it the hard way, iterating by grapheme cluster to avoid splitting them...
     result = 0
-    string_len = wcswidth if unicode_aware else len
-    char_len = wcwidth if unicode_aware else lambda x: 1
-    display_end = string_len(text)
-    while display_end > max_width:
-        result += 1
-        display_end -= char_len(text[0])
-        text = text[1:]
+    if unicode_aware:
+        display_end = wcswidth(text)
+        for grapheme in iter_graphemes(text):
+            if display_end <= max_width:
+                break
+            display_end -= wcswidth(grapheme)
+            result += len(grapheme)
+    else:
+        display_end = len(text)
+        while display_end > max_width:
+            result += 1
+            display_end -= 1
     if at_end and display_end == max_width:
-        result += 1
+        result += len(next(iter_graphemes(text[result:]), "")) if unicode_aware else 1
     return result
 
 
 def _get_offset(text: str, visible_width: int, unicode_aware: bool = True) -> int:
     """
     Find the character offset within some text for a given visible offset (taking into account the
-    fact that some character glyphs are double width).
+    fact that some character glyphs are double width and grapheme clusters).
 
     :param text: The text to analyze
     :param visible_width: The required location within that text (as seen on screen).
@@ -202,13 +212,12 @@ def _get_offset(text: str, visible_width: int, unicode_aware: bool = True) -> in
     result = 0
     width = 0
     if unicode_aware:
-        for char in text:
-            if visible_width - width <= 0:
+        for grapheme in iter_graphemes(text):
+            g_width = wcswidth(grapheme)
+            if width + g_width > visible_width:
                 break
-            result += 1
-            width += wcwidth(char)
-        if visible_width - width < 0:
-            result -= 1
+            result += len(grapheme)
+            width += g_width
     else:
         result = min(len(text), visible_width)
     return result
@@ -227,42 +236,51 @@ def _split_text(text: str, width: int, height: int, unicode_aware: bool = True) 
     :param height: The maximum height for the resulting text.
     :return: A list of strings of the broken up text.
     """
-    # At a high level, just try to split on whitespace for the best results.
-    tokens = text.split(" ")
-    result = []
-    current_line = ""
     string_len = wcswidth if unicode_aware else len
-    for token in tokens:
-        for i, line_token in enumerate(token.split("\n")):
-            if string_len(current_line + line_token) > width or i > 0:
-                # Don't bother inserting completely blank lines
-                # which should only happen on the very first
-                # line (as the rest will inject whitespace/newlines)
-                if len(current_line) > 0:
-                    result.append(current_line.rstrip())
-                current_line = line_token + " "
+
+    if unicode_aware:
+        # Use wcwidth.wrap() for grapheme, east-asian, emoji, and terminal sequence-aware word
+        # wrapping, modeled after standard python textwrap.wrap().  We split on newlines first to
+        # preserve newlines, as documented at bottom of API document of wcwidth.wrap(), its what
+        # most people prefer, like the html classic '<br><br><br>' sometimes you want them.
+        result = []
+        for paragraph in text.split("\n"):
+            if paragraph:
+                result.extend(wcwidth_wrap(paragraph, width, break_long_words=True))
             else:
-                current_line += line_token + " "
+                result.append("")
+    else:
+        # Legacy non-unicode path
+        tokens = text.split(" ")
+        result = []
+        current_line = ""
+        for token in tokens:
+            for i, line_token in enumerate(token.split("\n")):
+                if len(current_line + line_token) > width or i > 0:
+                    if len(current_line) > 0:
+                        result.append(current_line.rstrip())
+                    current_line = line_token + " "
+                else:
+                    current_line += line_token + " "
+        current_line = current_line.rstrip()
+        while len(current_line) > 0:
+            new_line = current_line[:width]
+            result.append(new_line)
+            current_line = current_line[len(new_line):]
 
-    # At this point we've either split nicely or have a hugely long unbroken string
-    # (e.g. because the language doesn't use whitespace.
-    # Either way, break this last line up as best we can.
-    current_line = current_line.rstrip()
-    while string_len(current_line) > 0:
-        new_line = str(_enforce_width(current_line, width, unicode_aware))
-        result.append(new_line)
-        current_line = current_line[len(new_line):]
-
-    # Check for a height overrun and truncate.
+    # Check for a height overrun and truncate with ellipsis.
     if len(result) > height:
         result = result[:height]
-        result[height - 1] = result[height - 1][:width - 3] + "..."
+        last_line = result[height - 1]
+        truncated = _enforce_width(last_line, width - 3, unicode_aware)
+        result[height - 1] = str(truncated) + "..."
 
     # Very small columns could be shorter than individual words - truncate
     # each line if necessary.
     for i, line in enumerate(result):
-        if len(line) > width:
-            result[i] = line[:width - 3] + "..."
+        if string_len(line) > width:
+            truncated = _enforce_width(line, width - 3, unicode_aware)
+            result[i] = str(truncated) + "..."
     return result
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ keywords = [
 dependencies = [
         'pyfiglet >= 0.7.2',
         'Pillow >= 2.7.0',
-        'wcwidth',
+        'wcwidth >= 0.5.0',
 	"pywin32 >= 1.0; platform_system=='Windows'",
 ]
 requires-python = ">= 3.8"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-wcwidth
+wcwidth >= 0.5
 pyfiglet >= 0.7.2
 setuptools_scm

--- a/tests/test_grapheme_clusters.py
+++ b/tests/test_grapheme_clusters.py
@@ -1,0 +1,156 @@
+"""Tests for grapheme cluster handling with wcwidth."""
+import unittest
+from wcwidth import wcswidth
+from asciimatics.widgets.utilities import (
+    _enforce_width, _find_min_start, _get_offset, _split_text,
+)
+from asciimatics.renderers import SpeechBubble
+
+FLAG_CA = "\U0001F1E8\U0001F1E6"
+FLAG_US = "\U0001F1FA\U0001F1F8"
+FAMILY = "\U0001F468\u200D\U0001F469\u200D\U0001F467"
+WAVE_SKIN = "\U0001F44B\U0001F3FB"
+CAFE = "cafe\u0301"
+CJK = "\u4E2D\u6587"
+HEART_VS16 = "\u2764\uFE0F"
+HEART = "\u2764"
+
+
+class TestEnforceWidth(unittest.TestCase):
+    """Tests for _enforce_width utility function."""
+
+    def test_ascii_and_cjk(self):
+        self.assertEqual(_enforce_width("Hello World", 5), "Hello")
+        self.assertEqual(_enforce_width("Short", 10), "Short")
+        self.assertEqual(_enforce_width(CJK + "test", 4), CJK)
+        self.assertEqual(_enforce_width(CJK, 3), "\u4E2D")
+
+    def test_preserves_grapheme_clusters(self):
+        self.assertEqual(_enforce_width("Hi" + FAMILY + "!", 4), "Hi" + FAMILY)
+        self.assertEqual(_enforce_width("A" + FLAG_CA + "B", 3), "A" + FLAG_CA)
+        self.assertEqual(_enforce_width(CAFE, 4), CAFE)
+        self.assertEqual(
+            _enforce_width("A" + WAVE_SKIN + "B", 3), "A" + WAVE_SKIN)
+
+    def test_variation_selectors(self):
+        self.assertEqual(_enforce_width("A" + HEART_VS16, 3), "A" + HEART_VS16)
+        self.assertEqual(_enforce_width("A" + HEART + "B", 2), "A" + HEART)
+
+
+class TestSplitText(unittest.TestCase):
+    """Tests for _split_text utility function."""
+
+    def setUp(self):
+        _split_text.cache_clear()
+
+    def test_basic_wrapping(self):
+        self.assertEqual(_split_text("hello world", 6, 3), ["hello", "world"])
+        self.assertEqual(len(_split_text("line1\nline2", 10, 3)), 2)
+
+    def test_ellipsis_and_long_words(self):
+        result = _split_text("line1 line2 line3 line4", 6, 2)
+        self.assertEqual(len(result), 2)
+        self.assertTrue(result[1].endswith("..."))
+        for line in _split_text("superlongword", 5, 3):
+            self.assertLessEqual(len(line), 5)
+
+    def test_cjk_width(self):
+        for line in _split_text(CJK + CJK + CJK, 4, 10):
+            self.assertLessEqual(wcswidth(line), 4)
+
+    def test_preserves_grapheme_clusters(self):
+        for line in _split_text(FAMILY + " " + FAMILY, 3, 3):
+            if FAMILY[0] in line:
+                self.assertIn(FAMILY, line)
+        for line in _split_text(FLAG_CA + " " + FLAG_US, 3, 3):
+            if "\U0001F1E8" in line:
+                self.assertIn(FLAG_CA, line)
+            if "\U0001F1FA" in line:
+                self.assertIn(FLAG_US, line)
+
+
+class TestFindMinStart(unittest.TestCase):
+    """Tests for _find_min_start utility function."""
+
+    def test_ascii_and_cjk(self):
+        self.assertEqual(_find_min_start("Hello", 3), 2)
+        self.assertEqual(_find_min_start("Hello", 5), 0)
+        self.assertEqual(_find_min_start(CJK, 2), 1)
+
+    def test_preserves_grapheme_clusters(self):
+        text = "A" + FAMILY + "B"
+        remaining = text[_find_min_start(text, 3):]
+        self.assertLessEqual(wcswidth(remaining), 3)
+        if FAMILY[0] in remaining:
+            self.assertIn(FAMILY, remaining)
+
+    def test_zwj_not_split(self):
+        text = "ABC" + FAMILY + "D"
+        remaining = text[_find_min_start(text, 3):]
+        self.assertNotIn("\u200D", remaining.rstrip(FAMILY + "D"))
+
+    def test_flag_not_split(self):
+        text = "ABC" + FLAG_CA + "D"
+        remaining = text[_find_min_start(text, 3):]
+        for ri in ["\U0001F1E8", "\U0001F1E6"]:
+            if ri in remaining:
+                self.assertIn(FLAG_CA, remaining)
+
+    def test_cluster_at_start_not_split(self):
+        text = FAMILY + "ABCD"
+        remaining = text[_find_min_start(text, 4):]
+        self.assertNotEqual(remaining[0] if remaining else '', '\u200D')
+        text = FLAG_CA + "ABCD"
+        remaining = text[_find_min_start(text, 4):]
+        self.assertNotEqual(remaining[0] if remaining else '', '\U0001F1E6')
+
+
+class TestGetOffset(unittest.TestCase):
+    """Tests for _get_offset utility function."""
+
+    def test_ascii_and_cjk(self):
+        self.assertEqual(_get_offset("Hello", 3), 3)
+        self.assertEqual(_get_offset("Hello", 5), 5)
+        self.assertEqual(_get_offset(CJK, 2), 1)
+        self.assertEqual(_get_offset(CJK, 4), 2)
+
+    def test_preserves_grapheme_clusters(self):
+        text = "A" + FAMILY + "B"
+        self.assertLessEqual(wcswidth(text[:_get_offset(text, 3)]), 3)
+
+    def test_zwj_not_split(self):
+        text = "A" + FAMILY + "B"
+        prefix = text[:_get_offset(text, 2)]
+        if '\u200D' in prefix:
+            self.assertIn(FAMILY, prefix)
+
+    def test_flag_not_split(self):
+        text = "A" + FLAG_CA + "B"
+        prefix = text[:_get_offset(text, 2)]
+        if '\U0001F1E8' in prefix:
+            self.assertIn(FLAG_CA, prefix)
+
+    def test_variation_selectors(self):
+        text = "A" + HEART_VS16 + "B"
+        self.assertLessEqual(wcswidth(text[:_get_offset(text, 3)]), 3)
+        text = "A" + HEART + "B"
+        self.assertEqual(_get_offset(text, 2), 2)
+
+
+class TestSpeechBubbleGrapheme(unittest.TestCase):
+    """Tests for SpeechBubble with grapheme clusters."""
+
+    def test_alignment(self):
+        for text in [FAMILY + "\nHi", CJK + "\nAB"]:
+            lines = repr(SpeechBubble(text)).split("\n")
+            self.assertEqual(wcswidth(lines[1]), wcswidth(lines[2]))
+
+    def test_mixed_width(self):
+        lines = repr(SpeechBubble("Hello\n" + FAMILY + CJK)).split("\n")
+        for line in lines[1:-1]:
+            if line.startswith("|"):
+                self.assertTrue(line.endswith("|"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] I read the [contributing guidelines](https://asciimatics.readthedocs.io/en/latest/contributing.html)
- [x] and that's why I include some flake8 and typing/mypy fixes
- [x] I also included comprehensive tests
- [x] many were designed with TDD (started failing, succeed after change).

Issues fixed by this PR
-----------------------

- I did not discover any *open* issues, I am surprised!
- You must not have many CJK and emoji uses.

What does this implement/fix?
-----------------------------

**Problem**: asciimatics text utilities wrongly split up grapheme clusters (emoji ZWJ sequences like 👨‍👩‍👧, regional flags like 🇨🇦, skin tone modifiers, combining characters, etc) -- this causes display corruption in the `SpeechBubble`, or incorrect width calculations and padding in other places due to missing grapheme support.

**Solution**: Integrate with `wcwidth>=0.5.0` by using:
  - [wcwidth.iter_graphemes()](https://wcwidth.readthedocs.io/en/latest/api.html#wcwidth.iter_graphemes) for iteration in ``_enforce_width_ext()``, ``_find_min_start()``, ``_get_offset()``.
  - [wcwidth.wrap()](https://wcwidth.readthedocs.io/en/latest/api.html#wcwidth.wrap) for grapheme-aware word wrapping in `_split_text()`.
     - Note that you can also pass-through ``**kwargs`` for all of the [additional built-in features](https://docs.python.org/3/library/textwrap.html#textwrap.wrap) supported by [wcwidth.wrap()](https://wcwidth.readthedocs.io/en/latest/api.html#wcwidth.wrap) also, like requested by #386 
  - [wcwidth.ljust()](https://wcwidth.readthedocs.io/en/latest/api.html#wcwidth.ljust) for line padding in SpeechBubble

Any other comments?
-------------------

- I notice that there is a choice to "ignore unicode" for performance improvement, but I can suggest that wcwidth has many "fast path" checks for pure-ascii strings to return len(string) and so on, along with lru_cache, the performance is negligble to always support unicode since, related downstream automatic benchmarking results can be [viewed here](https://github.com/peterbrittain/asciimatics/issues/155#issuecomment-3803386229) of upgrade of wcwidth: 

<details><summary>View benchmarks of wcwidth 0.2.14 to 0.5.0:</summary>

|     | Benchmark | `BASE` | `HEAD` | Efficiency |
| --- | --------- | ------ | ------ | ---------- |
| ⚡ | [`` test_center_ascii ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_center_ascii&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 104.8 µs | 62.1 µs | +68.87% |
| ⚡ | [`` test_rjust_cjk ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_rjust_cjk&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 760.6 µs | 640.2 µs | +18.81% |
| ⚡ | [`` test_center_cjk ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_center_cjk&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 763.5 µs | 642.6 µs | +18.81% |
| ⚡ | [`` test_truncate_ascii ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_truncate_ascii&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 33,519.5 µs | 83 µs | ×400 |
| ⚡ | [`` test_center_ansi ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_center_ansi&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 678.1 µs | 359.2 µs | +88.78% |
| ⚡ | [`` test_truncate_cjk ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_truncate_cjk&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 14.2 ms | 6.8 ms | ×2.1 |
| ⚡ | [`` test_length_cjk ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_length_cjk&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 749.7 µs | 633 µs | +18.45% |
| ⚡ | [`` test_truncate_emoji_zwj ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_truncate_emoji_zwj&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 5.2 ms | 1.6 ms | ×3.4 |
| ⚡ | [`` test_rjust_ansi ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_rjust_ansi&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 673.7 µs | 356.1 µs | +89.19% |
| ⚡ | [`` test_truncate_ansi ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_truncate_ansi&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 46.1 ms | 23.2 ms | +99.18% |
| ⚡ | [`` test_length_ansi ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_length_ansi&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 672.2 µs | 488.9 µs | +37.5% |
| ⚡ | [`` test_length_ascii ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_length_ascii&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 99.2 µs | 60.4 µs | +64.23% |
| ⚡ | [`` test_rjust_ascii ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_rjust_ascii&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 99.8 µs | 58.9 µs | +69.33% |
| ⚡ | [`` test_ljust_ansi ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_ljust_ansi&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 670.5 µs | 355.3 µs | +88.74% |
| ⚡ | [`` test_ljust_ascii ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_ljust_ascii&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 100.2 µs | 58.9 µs | +70.1% |
| ⚡ | [`` test_ljust_cjk ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_ljust_cjk&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 759.6 µs | 640.7 µs | +18.55% |
| ⚡ | [`` test_length_emoji_vs16 ``](https://codspeed.io/jquast/blessed/branches/jq%2Fwcwidth-0.3.0?uri=tests%2Ftest_benchmarks.py%3A%3Atest_length_emoji_vs16&runnerMode=Simulation&utm_source=github&utm_medium=comment&utm_content=benchmark) | 739.7 µs | 670.7 µs | +10.28% |

</details>

- I can also suggest it is possible to use ``try/except`` of ``import wcwidth``, with hasattr, making it an **optional co-dependency**, to help solve for #95 and #155

Let me know if you would like any such changes or additional PR's, happy to help.